### PR TITLE
auto-derive `primaryKey`

### DIFF
--- a/beam-core/Database/Beam/Schema/Tables.hs
+++ b/beam-core/Database/Beam/Schema/Tables.hs
@@ -56,6 +56,7 @@ module Database.Beam.Schema.Tables
     where
 
 import           Database.Beam.Backend.Types
+import           Database.Beam.Schema.Tables.GPrimaryKeyOf(GPrimaryKeyOf,gPrimaryKey)
 
 import           Control.Arrow (first)
 import           Control.Monad.Identity
@@ -520,7 +521,15 @@ class (Typeable table, Beamable table, Beamable (PrimaryKey table)) => Table (ta
 
     -- | Given a table, this should return the PrimaryKey from the table. By keeping this polymorphic over column,
     --   we ensure that the primary key values come directly from the table (i.e., they can't be arbitrary constants)
+    --
+    --   Whenever `PrimaryKey table column` and `table column` are generic, and the first rows from `PrimaryKey table column`
+    --   match those from `table column`, this function can be auto derived.
     primaryKey :: table column -> PrimaryKey table column
+    default primaryKey :: ( Generic (table column)
+                          , Generic (PrimaryKey table column)
+                          , GPrimaryKeyOf (Rep (PrimaryKey table column)) (Rep (table column))
+                          ) => table column -> PrimaryKey table column
+    primaryKey = to . fst . gPrimaryKey . from 
 
 -- | Provides a number of introspection routines for the beam library. Allows us
 --   to "zip" tables with different column tags together. Always instantiate an

--- a/beam-core/Database/Beam/Schema/Tables.hs
+++ b/beam-core/Database/Beam/Schema/Tables.hs
@@ -56,7 +56,8 @@ module Database.Beam.Schema.Tables
     where
 
 import           Database.Beam.Backend.Types
-import           Database.Beam.Schema.Tables.GPrimaryKeyOf(GPrimaryKeyOf,gPrimaryKey)
+import           Database.Beam.Schema.Tables.GPrimaryKeyOf(IsKeyDerivableFrom,derivedPrimaryKey)
+
 
 import           Control.Arrow (first)
 import           Control.Monad.Identity
@@ -525,11 +526,9 @@ class (Typeable table, Beamable table, Beamable (PrimaryKey table)) => Table (ta
     --   Whenever `PrimaryKey table column` and `table column` are generic, and the first rows from `PrimaryKey table column`
     --   match those from `table column`, this function can be auto derived.
     primaryKey :: table column -> PrimaryKey table column
-    default primaryKey :: ( Generic (table column)
-                          , Generic (PrimaryKey table column)
-                          , GPrimaryKeyOf (Rep (PrimaryKey table column)) (Rep (table column))
+    default primaryKey :: ( PrimaryKey table column `IsKeyDerivableFrom` table column
                           ) => table column -> PrimaryKey table column
-    primaryKey = to . fst . gPrimaryKey . from 
+    primaryKey = derivedPrimaryKey
 
 -- | Provides a number of introspection routines for the beam library. Allows us
 --   to "zip" tables with different column tags together. Always instantiate an

--- a/beam-core/Database/Beam/Schema/Tables/GPrimaryKeyOf.hs
+++ b/beam-core/Database/Beam/Schema/Tables/GPrimaryKeyOf.hs
@@ -1,0 +1,96 @@
+{-# LANGUAGE UndecidableInstances #-}
+
+module Database.Beam.Schema.Tables.GPrimaryKeyOf 
+     ( GPrimaryKeyOf()
+     , gPrimaryKey
+     ) where
+
+import GHC.Generics
+
+{- Whenever the first columns of a primary key matches the first columns of the table, it is possible to auto-derive
+   `primaryKey` based on `gPrimaryKey`.
+-}
+
+class GPrimaryKeyOf consumer producer where
+  -- | Constructors from `producer` unused after having taken the first
+  --   ones to create a `consumer`
+  type GRemainds consumer producer :: * -> *
+  
+  gPrimaryKey :: producer a -> (consumer a, GRemainds consumer producer a)
+
+
+instance ( GPrimaryKeyOf consumer producer
+         ) => GPrimaryKeyOf (D1 meta1 consumer) (D1 meta2 producer) 
+   where
+   
+    type GRemainds (D1 meta1 consumer) (D1 meta2 producer) = GRemainds consumer producer
+    gPrimaryKey (M1 x) = let (y,x') = gPrimaryKey x
+                          in (M1 y, x')
+
+instance ( GPrimaryKeyOf consumer producer
+         ) => GPrimaryKeyOf (C1 meta1 consumer) (C1 meta2 producer) 
+   where
+    type GRemainds (C1 meta1 consumer) (C1 meta2 producer) = GRemainds consumer producer
+    gPrimaryKey (M1 x) = let (y,x') = gPrimaryKey x
+                          in (M1 y, x')
+
+instance ( GPrimaryKeyOf consumer producer
+         ) => GPrimaryKeyOf (S1 meta1 consumer) (S1 meta2 producer) 
+   where
+    type GRemainds (S1 meta1 consumer) (S1 meta2 producer) = GRemainds consumer producer
+    gPrimaryKey (M1 x) = let (y,x') = gPrimaryKey x
+                          in (M1 y, x')
+
+
+instance GPrimaryKeyOf U1 producer where
+    type GRemainds U1 producer = producer
+    gPrimaryKey x = (U1,x)
+
+instance ( GPrimaryKeyOf consumer1 producer
+         , GPrimaryKeyOf consumer2 (GRemainds consumer1 producer)
+         
+         ) => GPrimaryKeyOf (consumer1 :*: consumer2) producer 
+   where
+    type GRemainds (consumer1 :*: consumer2) producer = GRemainds consumer2 (GRemainds consumer1 producer)
+    gPrimaryKey x = let (y1,x' ) = gPrimaryKey x
+                        (y2,x'') = gPrimaryKey x'
+                
+                     in ( y1:*:y2 , x'')
+
+
+instance GPrimaryKeyOf (K1 info1 a) (K1 info2 a) 
+   where
+    type GRemainds (K1 info1 a) (K1 info2 a) = U1
+    gPrimaryKey (K1 x) = (K1 x, U1)
+
+instance ( GPrimaryKeyOf (S1 info1 consumer) producer1
+         , TypeProduct (GRemainds (S1 info1 consumer) producer1) producer2
+                       (ProductIgnoringUnit (GRemainds (S1 info1 consumer) producer1) producer2)
+
+         ) => GPrimaryKeyOf (S1 info1 consumer) (producer1 :*: producer2) 
+   where
+    type GRemainds (S1 info1 consumer) (producer1 :*: producer2) = ProductIgnoringUnit (GRemainds (S1 info1 consumer) producer1) producer2
+    
+    gPrimaryKey (x1 :*: x2) = let (y,x1') = gPrimaryKey x1
+                               in (y, typeProduct x1' x2)
+
+---------------------------------------------------------------------------------------
+---------------------------------------------------------------------------------------
+-- Auxiliar classes:
+
+class TypeProduct a b c where
+    typeProduct :: a x -> b x -> c x
+
+instance TypeProduct U1 a a where
+    typeProduct _ a = a
+
+instance TypeProduct a b (a:*:b) where
+    typeProduct a b = a :*: b
+
+type family ProductIgnoringUnit (a :: * -> *) (b :: * -> *) :: * -> * where
+    ProductIgnoringUnit U1 g = g
+    ProductIgnoringUnit f  g = f :*: g
+
+
+
+

--- a/beam-core/Database/Beam/Schema/Tables/GPrimaryKeyOf.hs
+++ b/beam-core/Database/Beam/Schema/Tables/GPrimaryKeyOf.hs
@@ -1,82 +1,116 @@
 {-# LANGUAGE UndecidableInstances #-}
+{-# LANGUAGE ConstraintKinds      #-}
 
-module Database.Beam.Schema.Tables.GPrimaryKeyOf 
-     ( GPrimaryKeyOf()
-     , gPrimaryKey
+
+module Database.Beam.Schema.Tables.GPrimaryKeyOf
+     ( IsKeyDerivableFrom()
+     , derivedPrimaryKey
      ) where
 
 import GHC.Generics
-
+import GHC.TypeLits
+import GHC.Exts(Constraint)
+import Data.Proxy
 {- Whenever the first columns of a primary key matches the first columns of the table, it is possible to auto-derive
    `primaryKey` based on `gPrimaryKey`.
 -}
 
-class GPrimaryKeyOf consumer producer where
+
+class IsKeyDerivableFrom consumer producer where
+    derivedPrimaryKey :: producer -> consumer
+
+instance ( Generic consumer
+         , Generic producer
+         , GPrimaryKeyOf producer (Rep consumer) (Rep producer)
+         ) => IsKeyDerivableFrom consumer producer 
+   where
+    derivedPrimaryKey = to . fst . gPrimaryKey (Proxy :: Proxy producer) . from
+    
+
+class GPrimaryKeyOf debugInfo consumer producer where
   -- | Constructors from `producer` unused after having taken the first
   --   ones to create a `consumer`
   type GRemainds consumer producer :: * -> *
   
-  gPrimaryKey :: producer a -> (consumer a, GRemainds consumer producer a)
+  gPrimaryKey :: Proxy debugInfo -> producer a -> (consumer a, GRemainds consumer producer a)
 
 
-instance ( GPrimaryKeyOf consumer producer
-         ) => GPrimaryKeyOf (D1 meta1 consumer) (D1 meta2 producer) 
+instance ( GPrimaryKeyOf debugInfo consumer producer
+         ) => GPrimaryKeyOf debugInfo (D1 meta1 consumer) (D1 meta2 producer) 
    where
    
     type GRemainds (D1 meta1 consumer) (D1 meta2 producer) = GRemainds consumer producer
-    gPrimaryKey (M1 x) = let (y,x') = gPrimaryKey x
-                          in (M1 y, x')
+    gPrimaryKey debugInfo (M1 x) = let (y,x') = gPrimaryKey debugInfo x
+                                    in (M1 y, x')
 
-instance ( GPrimaryKeyOf consumer producer
-         ) => GPrimaryKeyOf (C1 meta1 consumer) (C1 meta2 producer) 
+instance ( GPrimaryKeyOf debugInfo consumer producer
+         ) => GPrimaryKeyOf debugInfo (C1 meta1 consumer) (C1 meta2 producer) 
    where
     type GRemainds (C1 meta1 consumer) (C1 meta2 producer) = GRemainds consumer producer
-    gPrimaryKey (M1 x) = let (y,x') = gPrimaryKey x
-                          in (M1 y, x')
+    gPrimaryKey debugInfo (M1 x) = let (y,x') = gPrimaryKey debugInfo x
+                                    in (M1 y, x')
 
-instance ( GPrimaryKeyOf consumer producer
-         ) => GPrimaryKeyOf (S1 meta1 consumer) (S1 meta2 producer) 
+instance ( GPrimaryKeyOf debugInfo consumer producer
+         ) => GPrimaryKeyOf debugInfo (S1 meta1 consumer) (S1 meta2 producer) 
    where
     type GRemainds (S1 meta1 consumer) (S1 meta2 producer) = GRemainds consumer producer
-    gPrimaryKey (M1 x) = let (y,x') = gPrimaryKey x
-                          in (M1 y, x')
+    gPrimaryKey debugInfo (M1 x) = let (y,x') = gPrimaryKey debugInfo x
+                                    in (M1 y, x')
 
 
-instance GPrimaryKeyOf U1 producer where
+instance GPrimaryKeyOf debugInfo U1 producer where
     type GRemainds U1 producer = producer
-    gPrimaryKey x = (U1,x)
+    gPrimaryKey _ x = (U1,x)
 
-instance ( GPrimaryKeyOf consumer1 producer
-         , GPrimaryKeyOf consumer2 (GRemainds consumer1 producer)
+instance ( GPrimaryKeyOf debugInfo consumer1 producer
+         , GPrimaryKeyOf debugInfo consumer2 (GRemainds consumer1 producer)
          
-         ) => GPrimaryKeyOf (consumer1 :*: consumer2) producer 
+         ) => GPrimaryKeyOf debugInfo (consumer1 :*: consumer2) producer 
    where
     type GRemainds (consumer1 :*: consumer2) producer = GRemainds consumer2 (GRemainds consumer1 producer)
-    gPrimaryKey x = let (y1,x' ) = gPrimaryKey x
-                        (y2,x'') = gPrimaryKey x'
+    gPrimaryKey debugInfo x = let (y1,x' ) = gPrimaryKey debugInfo x
+                                  (y2,x'') = gPrimaryKey debugInfo x'
                 
-                     in ( y1:*:y2 , x'')
+                               in ( y1:*:y2 , x'')
 
 
-instance GPrimaryKeyOf (K1 info1 a) (K1 info2 a) 
+instance GPrimaryKeyOf debugInfo (K1 info1 a) (K1 info2 a) 
    where
     type GRemainds (K1 info1 a) (K1 info2 a) = U1
-    gPrimaryKey (K1 x) = (K1 x, U1)
+    gPrimaryKey _ (K1 x) = (K1 x, U1)
 
-instance ( GPrimaryKeyOf (S1 info1 consumer) producer1
+
+instance ( ReportToLongPrimaryKey debugInfo
+         ) => GPrimaryKeyOf debugInfo (S1 info1 a) U1 
+   where
+    type GRemainds (S1 info1 a) U1 = U1
+    gPrimaryKey _ _ = error "this branch can not be reached"
+
+instance {-# INCOHERENT #-} 
+         ( ReportMissfitError debugInfo
+         ) => GPrimaryKeyOf debugInfo (K1 info1 a) (K1 info2 b) 
+   where
+    type GRemainds (K1 info1 a) (K1 info2 b) = U1
+    gPrimaryKey _ _ = error "this branch can not be reached"
+
+
+
+instance ( GPrimaryKeyOf debugInfo (S1 info1 consumer) producer1
          , TypeProduct (GRemainds (S1 info1 consumer) producer1) producer2
                        (ProductIgnoringUnit (GRemainds (S1 info1 consumer) producer1) producer2)
 
-         ) => GPrimaryKeyOf (S1 info1 consumer) (producer1 :*: producer2) 
+         ) => GPrimaryKeyOf debugInfo (S1 info1 consumer) (producer1 :*: producer2) 
    where
     type GRemainds (S1 info1 consumer) (producer1 :*: producer2) = ProductIgnoringUnit (GRemainds (S1 info1 consumer) producer1) producer2
     
-    gPrimaryKey (x1 :*: x2) = let (y,x1') = gPrimaryKey x1
-                               in (y, typeProduct x1' x2)
+    gPrimaryKey debugInfo (x1 :*: x2) = let (y,x1') = gPrimaryKey debugInfo x1
+                                         in (y, typeProduct x1' x2)
 
 ---------------------------------------------------------------------------------------
 ---------------------------------------------------------------------------------------
 -- Auxiliar classes:
+
+
 
 class TypeProduct a b c where
     typeProduct :: a x -> b x -> c x
@@ -92,5 +126,21 @@ type family ProductIgnoringUnit (a :: * -> *) (b :: * -> *) :: * -> * where
     ProductIgnoringUnit f  g = f :*: g
 
 
+
+type family ReportToLongPrimaryKey debugInfo :: Constraint where
+     ReportToLongPrimaryKey  debugInfo = TypeError 
+      (     'Text    "`primaryKey` for table:"
+      ':$$: 'ShowType debugInfo
+      ':$$: 'Text    "could not be derived because the table has more fields than its primary key."
+      ':$$: 'Text    "You must explicitly define the `primaryKey` method"
+      )
+
+type family ReportMissfitError debugInfo :: Constraint where
+     ReportMissfitError  debugInfo = TypeError 
+      (     'Text    "First primary key fields do not match first fields from the table:"
+      ':$$: 'ShowType debugInfo
+      ':$$: 'Text    "so function `primaryKey` could not be derived."
+      ':$$: 'Text    "You must either explicitly define or rearrange fields such they match."
+      )
 
 

--- a/beam-core/beam-core.cabal
+++ b/beam-core/beam-core.cabal
@@ -49,6 +49,7 @@ library
                        Database.Beam.Query.Operator
                        Database.Beam.Query.Ord
                        Database.Beam.Query.Relationships
+                       Database.Beam.Schema.Tables.GPrimaryKeyOf
 
                        Database.Beam.Schema.Lenses
   build-depends:       base         >=4.7     && <5.0,


### PR DESCRIPTION
When the first rows from the table define the primary key, the function `primaryKey` can be derived.

If an embeded beam appears on the table holding some columns used for the primary key, then the whole embeded beam shall appear on the primary key as is. This restriction could be lifted, so it would be possible to use "half" beam on the key (or even more, use a different set of beams on the primary keys and table) by using `Generic1` or ` {-# OVERLAPS #-}`, but I'm not sure that would be a good idea (or is there some suitable generalization that is appropriate?)

Example:
```
{-# LANGUAGE DerivingStrategies, DeriveAnyClass #-}

import Database.Beam
import Data.Text (Text)


data UserT f
    = User
    { _userEmail     :: Columnar f Text
    , _userFirstName :: Columnar f Text
    , _userLastName  :: Columnar f Text
    , _userPassword  :: Columnar f Text }
    deriving stock    Generic
    deriving anyclass Beamable

type User = UserT Identity
type UserId = PrimaryKey UserT Identity
deriving instance Show User
deriving instance Show UserId
deriving instance Eq User


instance Table UserT where
    data PrimaryKey UserT f = UserId (Columnar f Text) deriving stock    Generic
                                                       deriving anyclass Beamable 

main :: IO ()
main = let user = UserT "email@server.com" "John" "Johnson" "*****"
        in print ( primaryKey user :: UserId )
```