### PR TITLE
Update to Tutorial 3

### DIFF
--- a/docs/tutorials/tutorial3.md
+++ b/docs/tutorials/tutorial3.md
@@ -359,7 +359,7 @@ instance FromField ShippingCarrier where
                    case x of
                      Nothing -> returnError ConversionFailed f "Could not 'read' value for 'ShippingCarrier'"
                      Just x -> pure x
-instance FromBackendRow be ShippingCarrier
+instance FromBackendRow Sqlite ShippingCarrier
 ```
 
 Now, if we try to insert the shipping info again, it works.


### PR DESCRIPTION
If the reader copies and pastes the sample code containing `instance FromBackendRow be ShippingCarrier`, the example won't work unless `be` is replaced with the Sqlite backend.