### PR TITLE
Convert FromBackendRowM into a free applicative

### DIFF
--- a/beam-core/Database/Beam/Backend/SQL/Types.hs
+++ b/beam-core/Database/Beam/Backend/SQL/Types.hs
@@ -5,7 +5,6 @@ import Database.Beam.Backend.Types
 
 import qualified Data.Aeson as Json
 import           Data.Bits
-import           Data.Proxy
 
 class ( BeamBackend be ) =>
       BeamSqlBackend be where
@@ -18,8 +17,7 @@ newtype SqlBitString = SqlBitString Integer
 newtype SqlSerial a = SqlSerial { unSerial :: a }
   deriving (Show, Read, Eq, Ord, Num, Integral, Real, Enum)
 instance FromBackendRow be x => FromBackendRow be (SqlSerial x) where
-  fromBackendRow = SqlSerial <$> fromBackendRow
-  rowRep be _ = rowRep be (Proxy @x)
+  fromBackendRow = fmap SqlSerial <$> fromBackendRow
 instance Json.FromJSON a => Json.FromJSON (SqlSerial a) where
   parseJSON a = SqlSerial <$> Json.parseJSON a
 instance Json.ToJSON a => Json.ToJSON (SqlSerial a) where

--- a/beam-core/Database/Beam/Backend/SQL/Types.hs
+++ b/beam-core/Database/Beam/Backend/SQL/Types.hs
@@ -5,6 +5,7 @@ import Database.Beam.Backend.Types
 
 import qualified Data.Aeson as Json
 import           Data.Bits
+import           Data.Proxy
 
 class ( BeamBackend be ) =>
       BeamSqlBackend be where
@@ -18,6 +19,7 @@ newtype SqlSerial a = SqlSerial { unSerial :: a }
   deriving (Show, Read, Eq, Ord, Num, Integral, Real, Enum)
 instance FromBackendRow be x => FromBackendRow be (SqlSerial x) where
   fromBackendRow = SqlSerial <$> fromBackendRow
+  rowRep be _ = rowRep be (Proxy @x)
 instance Json.FromJSON a => Json.FromJSON (SqlSerial a) where
   parseJSON a = SqlSerial <$> Json.parseJSON a
 instance Json.ToJSON a => Json.ToJSON (SqlSerial a) where

--- a/beam-core/Database/Beam/Backend/Types.hs
+++ b/beam-core/Database/Beam/Backend/Types.hs
@@ -6,7 +6,7 @@
 
 module Database.Beam.Backend.Types
   ( BeamBackend(..)
-  , Result (..), BeamRowError (..)
+  , Result (..)
 
   , FromBackendRowF(..), FromBackendRowA
   , parseOneField, parseAlternative
@@ -18,10 +18,10 @@ module Database.Beam.Backend.Types
 
 import           Control.Applicative
 import           Control.Applicative.Free
-import           Control.Exception
 import           Control.Monad.Identity
 import           Data.Monoid (Sum(..))
 import           Data.Tagged
+import           Data.Text (Text)
 import           Data.Vector.Sized (Vector)
 import qualified Data.Vector.Sized as Vector
 
@@ -31,16 +31,10 @@ import GHC.Generics
 import GHC.TypeLits
 import GHC.Types
 
-data BeamRowError
-  = BeamRowError String
-  deriving (Eq, Show)
-
-instance Exception BeamRowError
-
 data Result a
   = Result a
   | Null
-  | Error BeamRowError
+  | Error Text
   deriving (Eq, Show, Functor)
 
 instance Applicative Result where

--- a/beam-core/Database/Beam/Backend/Types.hs
+++ b/beam-core/Database/Beam/Backend/Types.hs
@@ -55,12 +55,13 @@ class BeamBackend be => FromBackendRow be a where
   default fromBackendRow :: BackendFromField be a => FromBackendRowM be a
   fromBackendRow = parseOneField
 
-  valuesNeeded :: Proxy be -> Proxy a -> Int
-  valuesNeeded _ _ = 1
-
   rowRep :: Proxy be -> Proxy a -> [AnyField be]
   default rowRep :: BackendFromField be a => Proxy be -> Proxy a -> [AnyField be]
   rowRep _ _ = [AF (Proxy @a)]
+
+valuesNeeded :: FromBackendRow be a => Proxy be -> Proxy a -> Int
+valuesNeeded be a = length $ rowRep be a
+
 
 -- | newtype mainly used to inspect tho tag structure of a particular
 --   'Beamable'. Prevents overlapping instances in some case. Usually not used
@@ -79,66 +80,52 @@ data Nullable (c :: * -> *) x
 
 class GFromBackendRow be (exposed :: * -> *) rep where
   gFromBackendRow :: Proxy exposed -> FromBackendRowM be (rep ())
-  gValuesNeeded :: Proxy be -> Proxy exposed -> Proxy rep -> Int
   gRowRep :: Proxy be -> Proxy exposed -> Proxy rep -> [AnyField be]
 instance GFromBackendRow be e p => GFromBackendRow be (M1 t f e) (M1 t f p) where
   gFromBackendRow _ = M1 <$> gFromBackendRow (Proxy @e)
-  gValuesNeeded be _ _ = gValuesNeeded be (Proxy @e) (Proxy @p)
   gRowRep be _ _ = gRowRep be (Proxy @e) (Proxy @p)
 instance GFromBackendRow be e U1 where
   gFromBackendRow _ = pure U1
-  gValuesNeeded _ _ _ = 0
   gRowRep _ _ _ = []
 instance (GFromBackendRow be aExp a, GFromBackendRow be bExp b) => GFromBackendRow be (aExp :*: bExp) (a :*: b) where
   gFromBackendRow _ = (:*:) <$> gFromBackendRow (Proxy @aExp) <*> gFromBackendRow (Proxy @bExp)
-  gValuesNeeded be _ _ = gValuesNeeded be (Proxy @aExp) (Proxy @a) + gValuesNeeded be (Proxy @bExp) (Proxy @b)
   gRowRep be _ _ = gRowRep be (Proxy @aExp) (Proxy @a) ++ gRowRep be (Proxy @bExp) (Proxy @b)
 instance FromBackendRow be x => GFromBackendRow be (K1 R (Exposed x)) (K1 R x) where
   gFromBackendRow _ = K1 <$> fromBackendRow
-  gValuesNeeded be _ _ = valuesNeeded be (Proxy @x)
   gRowRep be _ _ = rowRep be (Proxy @x)
 instance FromBackendRow be (t Identity) => GFromBackendRow be (K1 R (t Exposed)) (K1 R (t Identity)) where
-    gFromBackendRow _ = K1 <$> fromBackendRow
-    gValuesNeeded be _ _ = valuesNeeded be (Proxy @(t Identity))
-    gRowRep be _ _ = rowRep be (Proxy @(t Identity))
+  gFromBackendRow _ = K1 <$> fromBackendRow
+  gRowRep be _ _ = rowRep be (Proxy @(t Identity))
 instance FromBackendRow be (t (Nullable Identity)) => GFromBackendRow be (K1 R (t (Nullable Exposed))) (K1 R (t (Nullable Identity))) where
-    gFromBackendRow _ = K1 <$> fromBackendRow
-    gValuesNeeded be _ _ = valuesNeeded be (Proxy @(t (Nullable Identity)))
-    gRowRep be _ _ = rowRep be (Proxy @(t (Nullable Identity)))
+  gFromBackendRow _ = K1 <$> fromBackendRow
+  gRowRep be _ _ = rowRep be (Proxy @(t (Nullable Identity)))
 instance BeamBackend be => FromBackendRow be () where
   fromBackendRow = to <$> gFromBackendRow (Proxy @(Rep ()))
-  valuesNeeded _ _ = 0
   rowRep _ _ = []
 
 instance ( BeamBackend be, KnownNat n, FromBackendRow be a ) => FromBackendRow be (Vector n a) where
   fromBackendRow = Vector.replicateM fromBackendRow
-  valuesNeeded _ _ = fromIntegral (natVal (Proxy @n))
   rowRep be a = concat $ replicate (fromIntegral $ natVal (Proxy @n)) (rowRep be a)
 
 instance ( BeamBackend be, FromBackendRow be a, FromBackendRow be b ) =>
   FromBackendRow be (a, b) where
   fromBackendRow = to <$> gFromBackendRow (Proxy @(Rep (Exposed a, Exposed b)))
-  valuesNeeded be _ = valuesNeeded be (Proxy @a) + valuesNeeded be (Proxy @b)
   rowRep be _ = rowRep be (Proxy @a) ++ rowRep be (Proxy @b)
 instance ( BeamBackend be, FromBackendRow be a, FromBackendRow be b, FromBackendRow be c ) =>
   FromBackendRow be (a, b, c) where
   fromBackendRow = to <$> gFromBackendRow (Proxy @(Rep (Exposed a, Exposed b, Exposed c)))
-  valuesNeeded be _ = valuesNeeded be (Proxy @a) + valuesNeeded be (Proxy @b) + valuesNeeded be (Proxy @c)
   rowRep be _ = concat [rowRep be (Proxy @a), rowRep be (Proxy @b), rowRep be (Proxy @c)]
 instance ( BeamBackend be
          , FromBackendRow be a, FromBackendRow be b, FromBackendRow be c
          , FromBackendRow be d ) =>
   FromBackendRow be (a, b, c, d) where
   fromBackendRow = to <$> gFromBackendRow (Proxy @(Rep (Exposed a, Exposed b, Exposed c, Exposed d)))
-  valuesNeeded be _ = valuesNeeded be (Proxy @a) + valuesNeeded be (Proxy @b) + valuesNeeded be (Proxy @c) + valuesNeeded be (Proxy @d)
   rowRep be _ = concat [rowRep be (Proxy @a), rowRep be (Proxy @b), rowRep be (Proxy @c), rowRep be (Proxy @d)]
 instance ( BeamBackend be
          , FromBackendRow be a, FromBackendRow be b, FromBackendRow be c
          , FromBackendRow be d, FromBackendRow be e ) =>
   FromBackendRow be (a, b, c, d, e) where
   fromBackendRow = to <$> gFromBackendRow (Proxy @(Rep (Exposed a, Exposed b, Exposed c, Exposed d, Exposed e)))
-  valuesNeeded be _ = valuesNeeded be (Proxy @a) + valuesNeeded be (Proxy @b) + valuesNeeded be (Proxy @c) + valuesNeeded be (Proxy @d) +
-                      valuesNeeded be (Proxy @e)
   rowRep be _ = concat [ rowRep be (Proxy @a), rowRep be (Proxy @b), rowRep be (Proxy @c), rowRep be (Proxy @d)
                        , rowRep be (Proxy @e)
                        ]
@@ -147,9 +134,7 @@ instance ( BeamBackend be
          , FromBackendRow be d, FromBackendRow be e, FromBackendRow be f ) =>
   FromBackendRow be (a, b, c, d, e, f) where
   fromBackendRow = to <$> gFromBackendRow (Proxy @(Rep (Exposed a, Exposed b, Exposed c, Exposed d, Exposed e, Exposed f)))
-  valuesNeeded be _ = valuesNeeded be (Proxy @a) + valuesNeeded be (Proxy @b) + valuesNeeded be (Proxy @c) + valuesNeeded be (Proxy @d) +
-                      valuesNeeded be (Proxy @e) + valuesNeeded be (Proxy @f)
-  rowRep be _ = concat [ rowRep be (Proxy @a), rowRep be (Proxy @b), rowRep be (Proxy @c), rowRep be (Proxy @d), rowRep be (Proxy @d)
+  rowRep be _ = concat [ rowRep be (Proxy @a), rowRep be (Proxy @b), rowRep be (Proxy @c), rowRep be (Proxy @d)
                        , rowRep be (Proxy @e), rowRep be (Proxy @f) ]
 instance ( BeamBackend be
          , FromBackendRow be a, FromBackendRow be b, FromBackendRow be c
@@ -157,9 +142,7 @@ instance ( BeamBackend be
          , FromBackendRow be g ) =>
   FromBackendRow be (a, b, c, d, e, f, g) where
   fromBackendRow = to <$> gFromBackendRow (Proxy @(Rep (Exposed a, Exposed b, Exposed c, Exposed d, Exposed e, Exposed f, Exposed g)))
-  valuesNeeded be _ = valuesNeeded be (Proxy @a) + valuesNeeded be (Proxy @b) + valuesNeeded be (Proxy @c) + valuesNeeded be (Proxy @d) +
-                      valuesNeeded be (Proxy @e) + valuesNeeded be (Proxy @f) + valuesNeeded be (Proxy @g)
-  rowRep be _ = concat [ rowRep be (Proxy @a), rowRep be (Proxy @b), rowRep be (Proxy @c), rowRep be (Proxy @d), rowRep be (Proxy @d)
+  rowRep be _ = concat [ rowRep be (Proxy @a), rowRep be (Proxy @b), rowRep be (Proxy @c), rowRep be (Proxy @d)
                        , rowRep be (Proxy @e), rowRep be (Proxy @f), rowRep be (Proxy @g) ]
 instance ( BeamBackend be
          , FromBackendRow be a, FromBackendRow be b, FromBackendRow be c
@@ -167,9 +150,7 @@ instance ( BeamBackend be
          , FromBackendRow be g, FromBackendRow be h ) =>
   FromBackendRow be (a, b, c, d, e, f, g, h) where
   fromBackendRow = to <$> gFromBackendRow (Proxy @(Rep (Exposed a, Exposed b, Exposed c, Exposed d, Exposed e, Exposed f, Exposed g, Exposed h)))
-  valuesNeeded be _ = valuesNeeded be (Proxy @a) + valuesNeeded be (Proxy @b) + valuesNeeded be (Proxy @c) + valuesNeeded be (Proxy @d) +
-                      valuesNeeded be (Proxy @e) + valuesNeeded be (Proxy @f) + valuesNeeded be (Proxy @g) + valuesNeeded be (Proxy @h)
-  rowRep be _ = concat [ rowRep be (Proxy @a), rowRep be (Proxy @b), rowRep be (Proxy @c), rowRep be (Proxy @d), rowRep be (Proxy @d)
+  rowRep be _ = concat [ rowRep be (Proxy @a), rowRep be (Proxy @b), rowRep be (Proxy @c), rowRep be (Proxy @d)
                        , rowRep be (Proxy @e), rowRep be (Proxy @f), rowRep be (Proxy @g), rowRep be (Proxy @h) ]
 
 instance ( BeamBackend be, Generic (tbl Identity), Generic (tbl Exposed)
@@ -177,21 +158,18 @@ instance ( BeamBackend be, Generic (tbl Identity), Generic (tbl Exposed)
 
     FromBackendRow be (tbl Identity) where
   fromBackendRow = to <$> gFromBackendRow (Proxy @(Rep (tbl Exposed)))
-  valuesNeeded be _ = gValuesNeeded be (Proxy @(Rep (tbl Exposed))) (Proxy @(Rep (tbl Identity)))
   rowRep be _ = gRowRep be (Proxy @(Rep (tbl Exposed))) (Proxy @(Rep (tbl Identity)))
 instance ( BeamBackend be, Generic (tbl (Nullable Identity)), Generic (tbl (Nullable Exposed))
          , GFromBackendRow be (Rep (tbl (Nullable Exposed))) (Rep (tbl (Nullable Identity)))) =>
 
     FromBackendRow be (tbl (Nullable Identity)) where
   fromBackendRow = to <$> gFromBackendRow (Proxy @(Rep (tbl (Nullable Exposed))))
-  valuesNeeded be _ = gValuesNeeded be (Proxy @(Rep (tbl (Nullable Exposed)))) (Proxy @(Rep (tbl (Nullable Identity))))
   rowRep be _ = gRowRep be (Proxy @(Rep (tbl (Nullable Exposed)))) (Proxy @(Rep (tbl (Nullable Identity))))
 
 instance FromBackendRow be x => FromBackendRow be (Maybe x) where
   fromBackendRow =
     do isNull <- checkNextNNull (valuesNeeded (Proxy @be) (Proxy @(Maybe x)))
        if isNull then pure Nothing else Just <$> fromBackendRow
-  valuesNeeded be _ = valuesNeeded be (Proxy @x)
   rowRep be _ = rowRep be (Proxy @x)
 
 deriving instance Generic (a, b, c, d, e, f, g, h)

--- a/beam-core/Database/Beam/Backend/Types.hs
+++ b/beam-core/Database/Beam/Backend/Types.hs
@@ -11,6 +11,8 @@ module Database.Beam.Backend.Types
 
   , FromBackendRow(..)
 
+  , AnyField(..)
+
   , Exposed, Nullable ) where
 
 import           Control.Monad.Free.Church
@@ -46,6 +48,8 @@ peekField = liftF (PeekField id)
 checkNextNNull :: Int -> FromBackendRowM be Bool
 checkNextNNull n = liftF (CheckNextNNull n id)
 
+data AnyField be = forall a. (BackendFromField be a) => AF (Proxy a)
+
 class BeamBackend be => FromBackendRow be a where
   fromBackendRow :: FromBackendRowM be a
   default fromBackendRow :: BackendFromField be a => FromBackendRowM be a
@@ -53,6 +57,10 @@ class BeamBackend be => FromBackendRow be a where
 
   valuesNeeded :: Proxy be -> Proxy a -> Int
   valuesNeeded _ _ = 1
+
+  rowRep :: Proxy be -> Proxy a -> [AnyField be]
+  default rowRep :: BackendFromField be a => Proxy be -> Proxy a -> [AnyField be]
+  rowRep _ _ = [AF (Proxy @a)]
 
 -- | newtype mainly used to inspect tho tag structure of a particular
 --   'Beamable'. Prevents overlapping instances in some case. Usually not used
@@ -72,46 +80,58 @@ data Nullable (c :: * -> *) x
 class GFromBackendRow be (exposed :: * -> *) rep where
   gFromBackendRow :: Proxy exposed -> FromBackendRowM be (rep ())
   gValuesNeeded :: Proxy be -> Proxy exposed -> Proxy rep -> Int
+  gRowRep :: Proxy be -> Proxy exposed -> Proxy rep -> [AnyField be]
 instance GFromBackendRow be e p => GFromBackendRow be (M1 t f e) (M1 t f p) where
   gFromBackendRow _ = M1 <$> gFromBackendRow (Proxy @e)
   gValuesNeeded be _ _ = gValuesNeeded be (Proxy @e) (Proxy @p)
+  gRowRep be _ _ = gRowRep be (Proxy @e) (Proxy @p)
 instance GFromBackendRow be e U1 where
   gFromBackendRow _ = pure U1
   gValuesNeeded _ _ _ = 0
+  gRowRep _ _ _ = []
 instance (GFromBackendRow be aExp a, GFromBackendRow be bExp b) => GFromBackendRow be (aExp :*: bExp) (a :*: b) where
   gFromBackendRow _ = (:*:) <$> gFromBackendRow (Proxy @aExp) <*> gFromBackendRow (Proxy @bExp)
   gValuesNeeded be _ _ = gValuesNeeded be (Proxy @aExp) (Proxy @a) + gValuesNeeded be (Proxy @bExp) (Proxy @b)
+  gRowRep be _ _ = gRowRep be (Proxy @aExp) (Proxy @a) ++ gRowRep be (Proxy @bExp) (Proxy @b)
 instance FromBackendRow be x => GFromBackendRow be (K1 R (Exposed x)) (K1 R x) where
   gFromBackendRow _ = K1 <$> fromBackendRow
   gValuesNeeded be _ _ = valuesNeeded be (Proxy @x)
+  gRowRep be _ _ = rowRep be (Proxy @x)
 instance FromBackendRow be (t Identity) => GFromBackendRow be (K1 R (t Exposed)) (K1 R (t Identity)) where
     gFromBackendRow _ = K1 <$> fromBackendRow
     gValuesNeeded be _ _ = valuesNeeded be (Proxy @(t Identity))
+    gRowRep be _ _ = rowRep be (Proxy @(t Identity))
 instance FromBackendRow be (t (Nullable Identity)) => GFromBackendRow be (K1 R (t (Nullable Exposed))) (K1 R (t (Nullable Identity))) where
     gFromBackendRow _ = K1 <$> fromBackendRow
     gValuesNeeded be _ _ = valuesNeeded be (Proxy @(t (Nullable Identity)))
+    gRowRep be _ _ = rowRep be (Proxy @(t (Nullable Identity)))
 instance BeamBackend be => FromBackendRow be () where
   fromBackendRow = to <$> gFromBackendRow (Proxy @(Rep ()))
   valuesNeeded _ _ = 0
+  rowRep _ _ = []
 
 instance ( BeamBackend be, KnownNat n, FromBackendRow be a ) => FromBackendRow be (Vector n a) where
   fromBackendRow = Vector.replicateM fromBackendRow
   valuesNeeded _ _ = fromIntegral (natVal (Proxy @n))
+  rowRep be a = concat $ replicate (fromIntegral $ natVal (Proxy @n)) (rowRep be a)
 
 instance ( BeamBackend be, FromBackendRow be a, FromBackendRow be b ) =>
   FromBackendRow be (a, b) where
   fromBackendRow = to <$> gFromBackendRow (Proxy @(Rep (Exposed a, Exposed b)))
   valuesNeeded be _ = valuesNeeded be (Proxy @a) + valuesNeeded be (Proxy @b)
+  rowRep be _ = rowRep be (Proxy @a) ++ rowRep be (Proxy @b)
 instance ( BeamBackend be, FromBackendRow be a, FromBackendRow be b, FromBackendRow be c ) =>
   FromBackendRow be (a, b, c) where
   fromBackendRow = to <$> gFromBackendRow (Proxy @(Rep (Exposed a, Exposed b, Exposed c)))
   valuesNeeded be _ = valuesNeeded be (Proxy @a) + valuesNeeded be (Proxy @b) + valuesNeeded be (Proxy @c)
+  rowRep be _ = concat [rowRep be (Proxy @a), rowRep be (Proxy @b), rowRep be (Proxy @c)]
 instance ( BeamBackend be
          , FromBackendRow be a, FromBackendRow be b, FromBackendRow be c
          , FromBackendRow be d ) =>
   FromBackendRow be (a, b, c, d) where
   fromBackendRow = to <$> gFromBackendRow (Proxy @(Rep (Exposed a, Exposed b, Exposed c, Exposed d)))
   valuesNeeded be _ = valuesNeeded be (Proxy @a) + valuesNeeded be (Proxy @b) + valuesNeeded be (Proxy @c) + valuesNeeded be (Proxy @d)
+  rowRep be _ = concat [rowRep be (Proxy @a), rowRep be (Proxy @b), rowRep be (Proxy @c), rowRep be (Proxy @d)]
 instance ( BeamBackend be
          , FromBackendRow be a, FromBackendRow be b, FromBackendRow be c
          , FromBackendRow be d, FromBackendRow be e ) =>
@@ -119,6 +139,9 @@ instance ( BeamBackend be
   fromBackendRow = to <$> gFromBackendRow (Proxy @(Rep (Exposed a, Exposed b, Exposed c, Exposed d, Exposed e)))
   valuesNeeded be _ = valuesNeeded be (Proxy @a) + valuesNeeded be (Proxy @b) + valuesNeeded be (Proxy @c) + valuesNeeded be (Proxy @d) +
                       valuesNeeded be (Proxy @e)
+  rowRep be _ = concat [ rowRep be (Proxy @a), rowRep be (Proxy @b), rowRep be (Proxy @c), rowRep be (Proxy @d)
+                       , rowRep be (Proxy @e)
+                       ]
 instance ( BeamBackend be
          , FromBackendRow be a, FromBackendRow be b, FromBackendRow be c
          , FromBackendRow be d, FromBackendRow be e, FromBackendRow be f ) =>
@@ -126,6 +149,8 @@ instance ( BeamBackend be
   fromBackendRow = to <$> gFromBackendRow (Proxy @(Rep (Exposed a, Exposed b, Exposed c, Exposed d, Exposed e, Exposed f)))
   valuesNeeded be _ = valuesNeeded be (Proxy @a) + valuesNeeded be (Proxy @b) + valuesNeeded be (Proxy @c) + valuesNeeded be (Proxy @d) +
                       valuesNeeded be (Proxy @e) + valuesNeeded be (Proxy @f)
+  rowRep be _ = concat [ rowRep be (Proxy @a), rowRep be (Proxy @b), rowRep be (Proxy @c), rowRep be (Proxy @d), rowRep be (Proxy @d)
+                       , rowRep be (Proxy @e), rowRep be (Proxy @f) ]
 instance ( BeamBackend be
          , FromBackendRow be a, FromBackendRow be b, FromBackendRow be c
          , FromBackendRow be d, FromBackendRow be e, FromBackendRow be f
@@ -134,6 +159,8 @@ instance ( BeamBackend be
   fromBackendRow = to <$> gFromBackendRow (Proxy @(Rep (Exposed a, Exposed b, Exposed c, Exposed d, Exposed e, Exposed f, Exposed g)))
   valuesNeeded be _ = valuesNeeded be (Proxy @a) + valuesNeeded be (Proxy @b) + valuesNeeded be (Proxy @c) + valuesNeeded be (Proxy @d) +
                       valuesNeeded be (Proxy @e) + valuesNeeded be (Proxy @f) + valuesNeeded be (Proxy @g)
+  rowRep be _ = concat [ rowRep be (Proxy @a), rowRep be (Proxy @b), rowRep be (Proxy @c), rowRep be (Proxy @d), rowRep be (Proxy @d)
+                       , rowRep be (Proxy @e), rowRep be (Proxy @f), rowRep be (Proxy @g) ]
 instance ( BeamBackend be
          , FromBackendRow be a, FromBackendRow be b, FromBackendRow be c
          , FromBackendRow be d, FromBackendRow be e, FromBackendRow be f
@@ -142,6 +169,8 @@ instance ( BeamBackend be
   fromBackendRow = to <$> gFromBackendRow (Proxy @(Rep (Exposed a, Exposed b, Exposed c, Exposed d, Exposed e, Exposed f, Exposed g, Exposed h)))
   valuesNeeded be _ = valuesNeeded be (Proxy @a) + valuesNeeded be (Proxy @b) + valuesNeeded be (Proxy @c) + valuesNeeded be (Proxy @d) +
                       valuesNeeded be (Proxy @e) + valuesNeeded be (Proxy @f) + valuesNeeded be (Proxy @g) + valuesNeeded be (Proxy @h)
+  rowRep be _ = concat [ rowRep be (Proxy @a), rowRep be (Proxy @b), rowRep be (Proxy @c), rowRep be (Proxy @d), rowRep be (Proxy @d)
+                       , rowRep be (Proxy @e), rowRep be (Proxy @f), rowRep be (Proxy @g), rowRep be (Proxy @h) ]
 
 instance ( BeamBackend be, Generic (tbl Identity), Generic (tbl Exposed)
          , GFromBackendRow be (Rep (tbl Exposed)) (Rep (tbl Identity))) =>
@@ -149,18 +178,21 @@ instance ( BeamBackend be, Generic (tbl Identity), Generic (tbl Exposed)
     FromBackendRow be (tbl Identity) where
   fromBackendRow = to <$> gFromBackendRow (Proxy @(Rep (tbl Exposed)))
   valuesNeeded be _ = gValuesNeeded be (Proxy @(Rep (tbl Exposed))) (Proxy @(Rep (tbl Identity)))
+  rowRep be _ = gRowRep be (Proxy @(Rep (tbl Exposed))) (Proxy @(Rep (tbl Identity)))
 instance ( BeamBackend be, Generic (tbl (Nullable Identity)), Generic (tbl (Nullable Exposed))
          , GFromBackendRow be (Rep (tbl (Nullable Exposed))) (Rep (tbl (Nullable Identity)))) =>
 
     FromBackendRow be (tbl (Nullable Identity)) where
   fromBackendRow = to <$> gFromBackendRow (Proxy @(Rep (tbl (Nullable Exposed))))
   valuesNeeded be _ = gValuesNeeded be (Proxy @(Rep (tbl (Nullable Exposed)))) (Proxy @(Rep (tbl (Nullable Identity))))
+  rowRep be _ = gRowRep be (Proxy @(Rep (tbl (Nullable Exposed)))) (Proxy @(Rep (tbl (Nullable Identity))))
 
 instance FromBackendRow be x => FromBackendRow be (Maybe x) where
   fromBackendRow =
     do isNull <- checkNextNNull (valuesNeeded (Proxy @be) (Proxy @(Maybe x)))
        if isNull then pure Nothing else Just <$> fromBackendRow
   valuesNeeded be _ = valuesNeeded be (Proxy @x)
+  rowRep be _ = rowRep be (Proxy @x)
 
 deriving instance Generic (a, b, c, d, e, f, g, h)
 
@@ -168,3 +200,4 @@ deriving instance Generic (a, b, c, d, e, f, g, h)
 
 instance (BeamBackend be, FromBackendRow be t) => FromBackendRow be (Tagged tag t) where
   fromBackendRow = Tagged <$> fromBackendRow
+  rowRep be _ = rowRep be (Proxy @t)

--- a/beam-core/Database/Beam/Backend/Types.hs
+++ b/beam-core/Database/Beam/Backend/Types.hs
@@ -6,16 +6,16 @@
 module Database.Beam.Backend.Types
   ( BeamBackend(..)
 
-  , FromBackendRowF(..), FromBackendRowM
-  , parseOneField, peekField, checkNextNNull
+  , FromBackendRowF(..), FromBackendRowA
+  , parseOneField, peekField
 
   , FromBackendRow(..)
-
-  , AnyField(..)
+  , valuesNeeded
 
   , Exposed, Nullable ) where
 
-import           Control.Monad.Free.Church
+import           Control.Applicative
+import           Control.Applicative.Free
 import           Control.Monad.Identity
 import           Data.Tagged
 import           Data.Vector.Sized (Vector)
@@ -33,35 +33,25 @@ class BeamBackend be where
   type BackendFromField be :: * -> Constraint
 
 data FromBackendRowF be f where
-  ParseOneField :: BackendFromField be a => (a -> f) -> FromBackendRowF be f
+  ParseOneField :: BackendFromField be a => (Maybe a -> f) -> FromBackendRowF be f
   PeekField :: BackendFromField be a => (Maybe a -> f) -> FromBackendRowF be f
-  CheckNextNNull :: Int -> (Bool -> f) -> FromBackendRowF be f
 deriving instance Functor (FromBackendRowF be)
-type FromBackendRowM be = F (FromBackendRowF be)
+type FromBackendRowA be = Ap (FromBackendRowF be)
 
-parseOneField :: BackendFromField be a => FromBackendRowM be a
-parseOneField = liftF (ParseOneField id)
+parseOneField :: BackendFromField be a => FromBackendRowA be (Maybe a)
+parseOneField = liftAp (ParseOneField id)
 
-peekField :: BackendFromField be a => FromBackendRowM be (Maybe a)
-peekField = liftF (PeekField id)
-
-checkNextNNull :: Int -> FromBackendRowM be Bool
-checkNextNNull n = liftF (CheckNextNNull n id)
-
-data AnyField be = forall a. (BackendFromField be a) => AF (Proxy a)
+peekField :: BackendFromField be a => FromBackendRowA be (Maybe a)
+peekField = liftAp (PeekField id)
 
 class BeamBackend be => FromBackendRow be a where
-  fromBackendRow :: FromBackendRowM be a
-  default fromBackendRow :: BackendFromField be a => FromBackendRowM be a
+  fromBackendRow :: FromBackendRowA be (Maybe a)
+  default fromBackendRow :: (BackendFromField be a) => FromBackendRowA be (Maybe a)
   fromBackendRow = parseOneField
 
-  rowRep :: Proxy be -> Proxy a -> [AnyField be]
-  default rowRep :: BackendFromField be a => Proxy be -> Proxy a -> [AnyField be]
-  rowRep _ _ = [AF (Proxy @a)]
-
-valuesNeeded :: FromBackendRow be a => Proxy be -> Proxy a -> Int
-valuesNeeded be a = length $ rowRep be a
-
+valuesNeeded :: FromBackendRowA be a -> Int
+valuesNeeded (Pure _) = 0
+valuesNeeded (Ap _ a) = 1 + valuesNeeded a
 
 -- | newtype mainly used to inspect tho tag structure of a particular
 --   'Beamable'. Prevents overlapping instances in some case. Usually not used
@@ -79,103 +69,97 @@ data Exposed x
 data Nullable (c :: * -> *) x
 
 class GFromBackendRow be (exposed :: * -> *) rep where
-  gFromBackendRow :: Proxy exposed -> FromBackendRowM be (rep ())
-  gRowRep :: Proxy be -> Proxy exposed -> Proxy rep -> [AnyField be]
-instance GFromBackendRow be e p => GFromBackendRow be (M1 t f e) (M1 t f p) where
-  gFromBackendRow _ = M1 <$> gFromBackendRow (Proxy @e)
-  gRowRep be _ _ = gRowRep be (Proxy @e) (Proxy @p)
+  gFromBackendRow :: Proxy exposed -> FromBackendRowA be (Maybe (rep ()))
 instance GFromBackendRow be e U1 where
-  gFromBackendRow _ = pure U1
-  gRowRep _ _ _ = []
-instance (GFromBackendRow be aExp a, GFromBackendRow be bExp b) => GFromBackendRow be (aExp :*: bExp) (a :*: b) where
-  gFromBackendRow _ = (:*:) <$> gFromBackendRow (Proxy @aExp) <*> gFromBackendRow (Proxy @bExp)
-  gRowRep be _ _ = gRowRep be (Proxy @aExp) (Proxy @a) ++ gRowRep be (Proxy @bExp) (Proxy @b)
+  gFromBackendRow _ = pure (Just U1)
+instance GFromBackendRow be e p => GFromBackendRow be (M1 t f e) (M1 t f p) where
+  gFromBackendRow _ = fmap M1 <$> gFromBackendRow (Proxy @e)
+instance (GFromBackendRow be ea a, GFromBackendRow be eb b) => GFromBackendRow be (ea :*: eb) (a :*: b) where
+  gFromBackendRow _ = liftA2 (:*:) <$> gFromBackendRow (Proxy @ea) <*> gFromBackendRow (Proxy @eb)
 instance FromBackendRow be x => GFromBackendRow be (K1 R (Exposed x)) (K1 R x) where
-  gFromBackendRow _ = K1 <$> fromBackendRow
-  gRowRep be _ _ = rowRep be (Proxy @x)
+  gFromBackendRow _ = fmap K1 <$> fromBackendRow
 instance FromBackendRow be (t Identity) => GFromBackendRow be (K1 R (t Exposed)) (K1 R (t Identity)) where
-  gFromBackendRow _ = K1 <$> fromBackendRow
-  gRowRep be _ _ = rowRep be (Proxy @(t Identity))
+  gFromBackendRow _ = fmap K1 <$> fromBackendRow
 instance FromBackendRow be (t (Nullable Identity)) => GFromBackendRow be (K1 R (t (Nullable Exposed))) (K1 R (t (Nullable Identity))) where
-  gFromBackendRow _ = K1 <$> fromBackendRow
-  gRowRep be _ _ = rowRep be (Proxy @(t (Nullable Identity)))
+  gFromBackendRow _ = fmap K1 <$> fromBackendRow
+
+
 instance BeamBackend be => FromBackendRow be () where
-  fromBackendRow = to <$> gFromBackendRow (Proxy @(Rep ()))
-  rowRep _ _ = []
+  fromBackendRow = pure (Just ())
 
 instance ( BeamBackend be, KnownNat n, FromBackendRow be a ) => FromBackendRow be (Vector n a) where
-  fromBackendRow = Vector.replicateM fromBackendRow
-  rowRep be a = concat $ replicate (fromIntegral $ natVal (Proxy @n)) (rowRep be a)
+  fromBackendRow = fmap sequenceA $ sequenceA $ Vector.replicate fromBackendRow
 
 instance ( BeamBackend be, FromBackendRow be a, FromBackendRow be b ) =>
   FromBackendRow be (a, b) where
-  fromBackendRow = to <$> gFromBackendRow (Proxy @(Rep (Exposed a, Exposed b)))
-  rowRep be _ = rowRep be (Proxy @a) ++ rowRep be (Proxy @b)
+  fromBackendRow = liftA2 (,) <$> fromBackendRow <*> fromBackendRow
+
 instance ( BeamBackend be, FromBackendRow be a, FromBackendRow be b, FromBackendRow be c ) =>
   FromBackendRow be (a, b, c) where
-  fromBackendRow = to <$> gFromBackendRow (Proxy @(Rep (Exposed a, Exposed b, Exposed c)))
-  rowRep be _ = concat [rowRep be (Proxy @a), rowRep be (Proxy @b), rowRep be (Proxy @c)]
-instance ( BeamBackend be
-         , FromBackendRow be a, FromBackendRow be b, FromBackendRow be c
-         , FromBackendRow be d ) =>
+  fromBackendRow = liftA3 (,,) <$> fromBackendRow <*> fromBackendRow <*> fromBackendRow
+
+instance ( BeamBackend be, FromBackendRow be a, FromBackendRow be b, FromBackendRow be c, FromBackendRow be d ) =>
   FromBackendRow be (a, b, c, d) where
-  fromBackendRow = to <$> gFromBackendRow (Proxy @(Rep (Exposed a, Exposed b, Exposed c, Exposed d)))
-  rowRep be _ = concat [rowRep be (Proxy @a), rowRep be (Proxy @b), rowRep be (Proxy @c), rowRep be (Proxy @d)]
-instance ( BeamBackend be
-         , FromBackendRow be a, FromBackendRow be b, FromBackendRow be c
-         , FromBackendRow be d, FromBackendRow be e ) =>
+  fromBackendRow = liftA4 (,,,) <$> fromBackendRow <*> fromBackendRow <*> fromBackendRow <*> fromBackendRow
+
+instance ( BeamBackend be, FromBackendRow be a, FromBackendRow be b, FromBackendRow be c, FromBackendRow be d
+                         , FromBackendRow be e ) =>
   FromBackendRow be (a, b, c, d, e) where
-  fromBackendRow = to <$> gFromBackendRow (Proxy @(Rep (Exposed a, Exposed b, Exposed c, Exposed d, Exposed e)))
-  rowRep be _ = concat [ rowRep be (Proxy @a), rowRep be (Proxy @b), rowRep be (Proxy @c), rowRep be (Proxy @d)
-                       , rowRep be (Proxy @e)
-                       ]
-instance ( BeamBackend be
-         , FromBackendRow be a, FromBackendRow be b, FromBackendRow be c
-         , FromBackendRow be d, FromBackendRow be e, FromBackendRow be f ) =>
+  fromBackendRow = liftA5 (,,,,) <$> fromBackendRow <*> fromBackendRow <*> fromBackendRow <*> fromBackendRow
+                                 <*> fromBackendRow
+
+instance ( BeamBackend be, FromBackendRow be a, FromBackendRow be b, FromBackendRow be c, FromBackendRow be d
+                         , FromBackendRow be e, FromBackendRow be f ) =>
   FromBackendRow be (a, b, c, d, e, f) where
-  fromBackendRow = to <$> gFromBackendRow (Proxy @(Rep (Exposed a, Exposed b, Exposed c, Exposed d, Exposed e, Exposed f)))
-  rowRep be _ = concat [ rowRep be (Proxy @a), rowRep be (Proxy @b), rowRep be (Proxy @c), rowRep be (Proxy @d)
-                       , rowRep be (Proxy @e), rowRep be (Proxy @f) ]
-instance ( BeamBackend be
-         , FromBackendRow be a, FromBackendRow be b, FromBackendRow be c
-         , FromBackendRow be d, FromBackendRow be e, FromBackendRow be f
-         , FromBackendRow be g ) =>
+  fromBackendRow = liftA6 (,,,,,) <$> fromBackendRow <*> fromBackendRow <*> fromBackendRow <*> fromBackendRow
+                                  <*> fromBackendRow <*> fromBackendRow
+
+instance ( BeamBackend be, FromBackendRow be a, FromBackendRow be b, FromBackendRow be c, FromBackendRow be d
+                         , FromBackendRow be e, FromBackendRow be f, FromBackendRow be g ) =>
   FromBackendRow be (a, b, c, d, e, f, g) where
-  fromBackendRow = to <$> gFromBackendRow (Proxy @(Rep (Exposed a, Exposed b, Exposed c, Exposed d, Exposed e, Exposed f, Exposed g)))
-  rowRep be _ = concat [ rowRep be (Proxy @a), rowRep be (Proxy @b), rowRep be (Proxy @c), rowRep be (Proxy @d)
-                       , rowRep be (Proxy @e), rowRep be (Proxy @f), rowRep be (Proxy @g) ]
-instance ( BeamBackend be
-         , FromBackendRow be a, FromBackendRow be b, FromBackendRow be c
-         , FromBackendRow be d, FromBackendRow be e, FromBackendRow be f
-         , FromBackendRow be g, FromBackendRow be h ) =>
+  fromBackendRow = liftA7 (,,,,,,) <$> fromBackendRow <*> fromBackendRow <*> fromBackendRow <*> fromBackendRow
+                                   <*> fromBackendRow <*> fromBackendRow <*> fromBackendRow
+
+instance ( BeamBackend be, FromBackendRow be a, FromBackendRow be b, FromBackendRow be c, FromBackendRow be d
+                         , FromBackendRow be e, FromBackendRow be f, FromBackendRow be g, FromBackendRow be h ) =>
   FromBackendRow be (a, b, c, d, e, f, g, h) where
-  fromBackendRow = to <$> gFromBackendRow (Proxy @(Rep (Exposed a, Exposed b, Exposed c, Exposed d, Exposed e, Exposed f, Exposed g, Exposed h)))
-  rowRep be _ = concat [ rowRep be (Proxy @a), rowRep be (Proxy @b), rowRep be (Proxy @c), rowRep be (Proxy @d)
-                       , rowRep be (Proxy @e), rowRep be (Proxy @f), rowRep be (Proxy @g), rowRep be (Proxy @h) ]
+  fromBackendRow = liftA8 (,,,,,,,) <$> fromBackendRow <*> fromBackendRow <*> fromBackendRow <*> fromBackendRow
+                                    <*> fromBackendRow <*> fromBackendRow <*> fromBackendRow <*> fromBackendRow
+
+instance FromBackendRow be a => FromBackendRow be (Maybe a) where
+  fromBackendRow = fmap f (fromBackendRow :: FromBackendRowA be (Maybe a))
+    where
+      f :: Maybe a -> Maybe (Maybe a)
+      f (Just a) = Just (Just a)
+      f Nothing = Just Nothing
 
 instance ( BeamBackend be, Generic (tbl Identity), Generic (tbl Exposed)
          , GFromBackendRow be (Rep (tbl Exposed)) (Rep (tbl Identity))) =>
-
     FromBackendRow be (tbl Identity) where
-  fromBackendRow = to <$> gFromBackendRow (Proxy @(Rep (tbl Exposed)))
-  rowRep be _ = gRowRep be (Proxy @(Rep (tbl Exposed))) (Proxy @(Rep (tbl Identity)))
+  fromBackendRow = fmap to <$> gFromBackendRow (Proxy @(Rep (tbl Exposed)))
+
 instance ( BeamBackend be, Generic (tbl (Nullable Identity)), Generic (tbl (Nullable Exposed))
          , GFromBackendRow be (Rep (tbl (Nullable Exposed))) (Rep (tbl (Nullable Identity)))) =>
-
     FromBackendRow be (tbl (Nullable Identity)) where
-  fromBackendRow = to <$> gFromBackendRow (Proxy @(Rep (tbl (Nullable Exposed))))
-  rowRep be _ = gRowRep be (Proxy @(Rep (tbl (Nullable Exposed)))) (Proxy @(Rep (tbl (Nullable Identity))))
-
-instance FromBackendRow be x => FromBackendRow be (Maybe x) where
-  fromBackendRow =
-    do isNull <- checkNextNNull (valuesNeeded (Proxy @be) (Proxy @(Maybe x)))
-       if isNull then pure Nothing else Just <$> fromBackendRow
-  rowRep be _ = rowRep be (Proxy @x)
-
-deriving instance Generic (a, b, c, d, e, f, g, h)
+  fromBackendRow = fmap to <$> gFromBackendRow (Proxy @(Rep (tbl (Nullable Exposed))))
 
 -- Tagged
 
 instance (BeamBackend be, FromBackendRow be t) => FromBackendRow be (Tagged tag t) where
-  fromBackendRow = Tagged <$> fromBackendRow
-  rowRep be _ = rowRep be (Proxy @t)
+  fromBackendRow = fmap Tagged <$> fromBackendRow
+
+liftA4 :: Applicative f => (a1 -> a2 -> a3 -> a4 -> b) -> f a1 -> f a2 -> f a3 -> f a4 -> f b
+liftA4 f a1 a2 a3 a4 = f <$> a1 <*> a2 <*> a3 <*> a4
+
+liftA5 :: Applicative f => (a1 -> a2 -> a3 -> a4 -> a5 -> b) -> f a1 -> f a2 -> f a3 -> f a4 -> f a5 -> f b
+liftA5 f a1 a2 a3 a4 a5 = f <$> a1 <*> a2 <*> a3 <*> a4 <*> a5
+
+liftA6 :: Applicative f => (a1 -> a2 -> a3 -> a4 -> a5 -> a6 -> b) -> f a1 -> f a2 -> f a3 -> f a4 -> f a5 -> f a6 -> f b
+liftA6 f a1 a2 a3 a4 a5 a6 = f <$> a1 <*> a2 <*> a3 <*> a4 <*> a5 <*> a6
+
+liftA7 :: Applicative f => (a1 -> a2 -> a3 -> a4 -> a5 -> a6 -> a7 -> b) -> f a1 -> f a2 -> f a3 -> f a4 -> f a5 -> f a6 -> f a7 -> f b
+liftA7 f a1 a2 a3 a4 a5 a6 a7 = f <$> a1 <*> a2 <*> a3 <*> a4 <*> a5 <*> a6 <*> a7
+
+liftA8 :: Applicative f => (a1 -> a2 -> a3 -> a4 -> a5 -> a6 -> a7 -> a8 -> b) -> f a1 -> f a2 -> f a3 -> f a4 -> f a5 -> f a6 -> f a7 -> f a8 -> f b
+liftA8 f a1 a2 a3 a4 a5 a6 a7 a8 = f <$> a1 <*> a2 <*> a3 <*> a4 <*> a5 <*> a6 <*> a7 <*> a8
+

--- a/beam-core/Database/Beam/Backend/Types.hs
+++ b/beam-core/Database/Beam/Backend/Types.hs
@@ -20,6 +20,7 @@ import           Control.Applicative
 import           Control.Applicative.Free
 import           Control.Exception
 import           Control.Monad.Identity
+import           Data.Monoid (Sum(..))
 import           Data.Tagged
 import           Data.Vector.Sized (Vector)
 import qualified Data.Vector.Sized as Vector
@@ -76,8 +77,7 @@ class BeamBackend be => FromBackendRow be a where
   fromBackendRow = parseOneField
 
 valuesNeeded :: FromBackendRowA be a -> Int
-valuesNeeded (Pure _) = 0
-valuesNeeded (Ap _ a) = 1 + valuesNeeded a
+valuesNeeded = getSum . runAp_ (\_ -> Sum 1)
 
 -- | newtype mainly used to inspect tho tag structure of a particular
 --   'Beamable'. Prevents overlapping instances in some case. Usually not used
@@ -188,4 +188,3 @@ liftA7 f a1 a2 a3 a4 a5 a6 a7 = f <$> a1 <*> a2 <*> a3 <*> a4 <*> a5 <*> a6 <*> 
 
 liftA8 :: Applicative f => (a1 -> a2 -> a3 -> a4 -> a5 -> a6 -> a7 -> a8 -> b) -> f a1 -> f a2 -> f a3 -> f a4 -> f a5 -> f a6 -> f a7 -> f a8 -> f b
 liftA8 f a1 a2 a3 a4 a5 a6 a7 a8 = f <$> a1 <*> a2 <*> a3 <*> a4 <*> a5 <*> a6 <*> a7 <*> a8
-

--- a/beam-core/Database/Beam/Backend/Types.hs
+++ b/beam-core/Database/Beam/Backend/Types.hs
@@ -127,11 +127,7 @@ instance ( BeamBackend be, FromBackendRow be a, FromBackendRow be b, FromBackend
                                     <*> fromBackendRow <*> fromBackendRow <*> fromBackendRow <*> fromBackendRow
 
 instance FromBackendRow be a => FromBackendRow be (Maybe a) where
-  fromBackendRow = fmap f (fromBackendRow :: FromBackendRowA be (Maybe a))
-    where
-      f :: Maybe a -> Maybe (Maybe a)
-      f (Just a) = Just (Just a)
-      f Nothing = Just Nothing
+  fromBackendRow = fmap Just (fromBackendRow :: FromBackendRowA be (Maybe a))
 
 instance ( BeamBackend be, Generic (tbl Identity), Generic (tbl Exposed)
          , GFromBackendRow be (Rep (tbl Exposed)) (Rep (tbl Identity))) =>

--- a/beam-postgres/Database/Beam/Postgres/Conduit.hs
+++ b/beam-postgres/Database/Beam/Postgres/Conduit.hs
@@ -147,10 +147,10 @@ runQueryReturning conn x withSrc = do
               do fields' <- liftIO (maybe (getFields row) pure fields)
                  parsedRow <- liftIO (runPgRowReader conn 0 row fields' fromBackendRow)
                  case parsedRow of
-                    Left err -> liftIO (bailEarly row ("Could not read row: " <> show err))
-                    Right parsedRow' ->
-                      do C.yield parsedRow'
-                         streamResults (Just fields')
+                   Left err -> liftIO (bailEarly row ("Could not read row: " <> show err))
+                   Right parsedRow' ->
+                     do C.yield parsedRow'
+                        streamResults (Just fields')
             Pg.TuplesOk -> liftIO (Pg.withConnection conn finishQuery)
             Pg.EmptyQuery -> fail "No query"
             Pg.CommandOk -> pure ()

--- a/beam-postgres/Database/Beam/Postgres/Conduit.hs
+++ b/beam-postgres/Database/Beam/Postgres/Conduit.hs
@@ -129,13 +129,14 @@ runQueryReturning conn x withSrc = do
     then do
       singleRowModeSet <- liftIO (Pg.withConnection conn Pg.setSingleRowMode)
       if singleRowModeSet
-         then withSrc (streamResults Nothing) `finally` gracefulShutdown
+         then error "TODO" -- withSrc (streamResults Nothing) `finally` gracefulShutdown
          else fail "Could not enable single row mode"
     else do
       errMsg <- fromMaybe "No libpq error provided" <$> liftIO (Pg.withConnection conn Pg.errorMessage)
       fail (show errMsg)
 
   where
+    {-
     streamResults fields = do
       nextRow <- liftIO (Pg.withConnection conn Pg.getResult)
       case nextRow of
@@ -156,6 +157,7 @@ runQueryReturning conn x withSrc = do
             Pg.CommandOk -> pure ()
             _ -> do errMsg <- liftIO (Pg.resultErrorMessage row)
                     fail ("Postgres error: " <> show errMsg)
+     -}
 
     bailEarly row errorString = do
       Pg.unsafeFreeResult row
@@ -178,6 +180,7 @@ runQueryReturning conn x withSrc = do
         Nothing -> pure ()
         Just _ -> finishQuery conn'
 
+    {-
     gracefulShutdown =
       liftIO . Pg.withConnection conn $ \conn' ->
       do sts <- Pg.transactionStatus conn'
@@ -187,3 +190,4 @@ runQueryReturning conn x withSrc = do
            Pg.TransInError -> pure ()
            Pg.TransUnknown -> pure ()
            Pg.TransActive -> cancelQuery conn'
+    -}

--- a/beam-postgres/Database/Beam/Postgres/Types.hs
+++ b/beam-postgres/Database/Beam/Postgres/Types.hs
@@ -12,7 +12,6 @@ module Database.Beam.Postgres.Types
 
 import           Database.Beam
 import           Database.Beam.Backend.SQL
-import           Database.Beam.Backend.Types
 
 import qualified Database.PostgreSQL.Simple.FromField as Pg
 import qualified Database.PostgreSQL.Simple.HStore as Pg (HStoreMap, HStoreList)

--- a/beam-postgres/Database/Beam/Postgres/Types.hs
+++ b/beam-postgres/Database/Beam/Postgres/Types.hs
@@ -49,7 +49,7 @@ instance Pg.FromField SqlNull where
 
 fromScientificOrIntegral :: forall a. (Bounded a, Integral a) => FromBackendRowA Postgres (Result a)
 fromScientificOrIntegral =
-  parseAlternative (maybe (Error $ BeamRowError "fromScientificOrIntegral: downcasting would result in loss of data") Result <$> toBoundedInteger)
+  parseAlternative (maybe (Error "fromScientificOrIntegral: downcasting would result in loss of data") Result <$> toBoundedInteger)
                    (Result . (fromIntegral :: Integer -> a))
 
 fromPgIntegral :: forall a. (Pg.FromField a, Integral a) => FromBackendRowA Postgres (Result a)
@@ -60,7 +60,7 @@ fromPgIntegral = parseAlternative Result f
       let x' = fromIntegral x
       in if x == fromIntegral x'
            then Result x'
-           else Error $ BeamRowError "fromPgIntegral: downcasting would result in loss of data"
+           else Error "fromPgIntegral: downcasting would result in loss of data"
 
 -- Default FromBackendRow instances for all postgresql-simple FromField instances
 instance FromBackendRow Postgres SqlNull

--- a/beam-postgres/beam-postgres.cabal
+++ b/beam-postgres/beam-postgres.cabal
@@ -42,6 +42,7 @@ library
                       time                 >=1.6  && <1.10,
                       monad-control        >=1.0  && <1.1,
                       mtl                  >=2.1  && <2.3,
+                      transformers         >=0.5  && <0.6,
                       conduit              >=1.2  && <1.4,
                       aeson                >=0.11 && <1.5,
                       uuid-types           >=1.0  && <1.1,


### PR DESCRIPTION
This is a work in progress.

There are already some clear trade-offs to this approach so I'm submitting here for review.

Pros:
* Result can be read sequentially i.e. no backtracking/lookahead. With a little luck we can implement `ParseAlternative` so that each column in the result is read exactly once. `CheckNNull` is thus gone - it would be useless with only applicative anyway.
* Every `fromBackendRow` can be statically analyzed to get the [number of values needed](https://github.com/mulderr/beam/blob/3c6e9e679637002745774cce9e988635cea8efeb/beam-core/Database/Beam/Backend/Types.hs#L78) without having to define it at the instance level.
* Backend libraries can do their own weird things like [inspecting types of fields](https://github.com/mulderr/beam-oracle/blob/fab1f03fb1cd85e7a41eff8a191e4b94fdac293f/src/Database/Beam/Oracle/Connection.hs#L78) without having to impose new functionality on beam-core.

Cons:
* Errors regarding nullability can be delayed and less informative, we basically thread null up the chain until a `Maybe` "catches" it or the whole computation results in null which should cause the interpreter to throw. The problem is exacerbated by nested `Maybe`s resulting from outer joins - otherwise we could possibly short circuit in the `Applicative` instance of `Result` by having a mix of `Null` and `Result x` be an `Error`.
* Well, to point out the elephant in the room, applicative is more restrictive than monad. Currently I cannot see any instances that strictly require monad but that doesn't mean anything. If you can think of an immediately useful one (or one that requires more than `FromBackendRowF` as defined here permits) do say!

TODO:
- [ ] try to improve error reporting, it's not been given much care up until this point
- [x] `Database.Beam.Postgres.Conduit` still has some things commented out
- [ ] fix errors when building docs for beam-postgres
- [ ] benchmarking