### PR TITLE
Improve integer size translations

### DIFF
--- a/beam-migrate/Database/Beam/Migrate/Generics/Tables.hs
+++ b/beam-migrate/Database/Beam/Migrate/Generics/Tables.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE CPP #-}
 {-# LANGUAGE ConstraintKinds #-}
 {-# LANGUAGE UndecidableInstances #-}
 
@@ -11,6 +12,8 @@ module Database.Beam.Migrate.Generics.Tables
 
   , HasNullableConstraint, NullableStatus
   ) where
+
+#include "MachDeps.h"
 
 import Database.Beam
 import Database.Beam.Backend.SQL
@@ -133,8 +136,17 @@ instance (BeamMigrateSqlBackend be, HasDefaultSqlDataType be ty) =>
 
 -- TODO Not sure if individual databases will want to customize these types
 
+
+#if WORD_SIZE_IN_BITS == 32
 instance BeamMigrateSqlBackend be => HasDefaultSqlDataType be Int where
   defaultSqlDataType _ = defaultSqlDataType (Proxy @Int32)
+#elif WORD_SIZE_IN_BITS == 64
+instance ( BeamMigrateSqlBackend be, BeamSqlT071Backend be ) => HasDefaultSqlDataType be Int where
+  defaultSqlDataType _ = defaultSqlDataType (Proxy @Int64)
+#else
+#error "Unsupported word size; check the value of WORD_SIZE_IN_BITS"
+#endif
+
 instance BeamMigrateSqlBackend be => HasDefaultSqlDataType be Int32 where
   defaultSqlDataType _ _ _ = intType
 instance BeamMigrateSqlBackend be => HasDefaultSqlDataType be Int16 where

--- a/beam-migrate/Database/Beam/Migrate/Generics/Tables.hs
+++ b/beam-migrate/Database/Beam/Migrate/Generics/Tables.hs
@@ -138,7 +138,7 @@ instance BeamMigrateSqlBackend be => HasDefaultSqlDataType be Int where
 instance BeamMigrateSqlBackend be => HasDefaultSqlDataType be Int32 where
   defaultSqlDataType _ _ _ = intType
 instance BeamMigrateSqlBackend be => HasDefaultSqlDataType be Int16 where
-  defaultSqlDataType _ _ _ = intType
+  defaultSqlDataType _ _ _ = smallIntType
 instance ( BeamMigrateSqlBackend be, BeamSqlT071Backend be ) => HasDefaultSqlDataType be Int64 where
     defaultSqlDataType _ _ _ = bigIntType
 

--- a/beam-migrate/Database/Beam/Migrate/Generics/Tables.hs
+++ b/beam-migrate/Database/Beam/Migrate/Generics/Tables.hs
@@ -134,7 +134,7 @@ instance (BeamMigrateSqlBackend be, HasDefaultSqlDataType be ty) =>
 -- TODO Not sure if individual databases will want to customize these types
 
 instance BeamMigrateSqlBackend be => HasDefaultSqlDataType be Int where
-  defaultSqlDataType _ _ _ = intType
+  defaultSqlDataType _ = defaultSqlDataType (Proxy @Int32)
 instance BeamMigrateSqlBackend be => HasDefaultSqlDataType be Int32 where
   defaultSqlDataType _ _ _ = intType
 instance BeamMigrateSqlBackend be => HasDefaultSqlDataType be Int16 where

--- a/beam-postgres/Database/Beam/Postgres/Types.hs
+++ b/beam-postgres/Database/Beam/Postgres/Types.hs
@@ -1,5 +1,6 @@
 {-# OPTIONS_GHC -fno-warn-orphans #-}
 
+{-# LANGUAGE CPP #-}
 {-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE UndecidableInstances #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
@@ -10,6 +11,8 @@
 
 module Database.Beam.Postgres.Types
   ( Postgres(..) ) where
+
+#include "MachDeps.h"
 
 import           Database.Beam
 import           Database.Beam.Backend
@@ -173,9 +176,15 @@ instance HasDefaultSqlDataType Postgres ByteString where
 instance HasDefaultSqlDataType Postgres LocalTime where
   defaultSqlDataType _ _ _ = timestampType Nothing False
 
+#if WORD_SIZE_IN_BITS == 32
 instance HasDefaultSqlDataType Postgres (SqlSerial Int) where
   defaultSqlDataType _ = defaultSqlDataType (Proxy @(SqlSerial Int32))
+#elif WORD_SIZE_IN_BITS == 64
 instance HasDefaultSqlDataType Postgres (SqlSerial Int) where
+  defaultSqlDataType _ = defaultSqlDataType (Proxy @(SqlSerial Int64))
+#else
+#error "Unsupported word size; check the value of WORD_SIZE_IN_BITS"
+#endif
 
 instance HasDefaultSqlDataType Postgres (SqlSerial Int16) where
   defaultSqlDataType _ _ False = pgSmallSerialType

--- a/beam-postgres/Database/Beam/Postgres/Types.hs
+++ b/beam-postgres/Database/Beam/Postgres/Types.hs
@@ -4,6 +4,7 @@
 {-# LANGUAGE UndecidableInstances #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
 {-# LANGUAGE OverloadedStrings #-}
 
@@ -28,6 +29,7 @@ import           Data.ByteString (ByteString)
 import qualified Data.ByteString.Lazy as BL
 import           Data.CaseInsensitive (CI)
 import           Data.Int
+import           Data.Proxy
 import           Data.Ratio (Ratio)
 import           Data.Scientific (Scientific, toBoundedInteger)
 import           Data.Tagged
@@ -172,8 +174,20 @@ instance HasDefaultSqlDataType Postgres LocalTime where
   defaultSqlDataType _ _ _ = timestampType Nothing False
 
 instance HasDefaultSqlDataType Postgres (SqlSerial Int) where
+  defaultSqlDataType _ = defaultSqlDataType (Proxy @(SqlSerial Int32))
+instance HasDefaultSqlDataType Postgres (SqlSerial Int) where
+
+instance HasDefaultSqlDataType Postgres (SqlSerial Int16) where
+  defaultSqlDataType _ _ False = pgSmallSerialType
+  defaultSqlDataType _ _ _ = smallIntType
+
+instance HasDefaultSqlDataType Postgres (SqlSerial Int32) where
   defaultSqlDataType _ _ False = pgSerialType
   defaultSqlDataType _ _ _ = intType
+
+instance HasDefaultSqlDataType Postgres (SqlSerial Int64) where
+  defaultSqlDataType _ _ False = pgBigSerialType
+  defaultSqlDataType _ _ _ = bigIntType
 
 instance HasDefaultSqlDataType Postgres UUID where
   defaultSqlDataType _ _ _ = pgUuidType


### PR DESCRIPTION
This branch includes three commits:
* Support `SqlSerial Int16`, `SqlSerial Int32`, and `SqlSerial Int64`
* Change the representation of Int16 to be SMALLINT
* Change the representation of Int to be BIGINT when it is 64 bits wide (but keep it as INTEGER when it is 32 bits wide)

I'm not entirely sure whether the latter two are actually a good idea - personally, I wouldn't use `Int` at all for SQL.  However, it seemed more correct to do it this way.  Let me know if you'd prefer I send these PRs separately or dice it up in some other way.