### PR TITLE
Fix emitting of SQL 92 DECIMAL type

### DIFF
--- a/beam-core/Database/Beam/Backend/SQL/Builder.hs
+++ b/beam-core/Database/Beam/Backend/SQL/Builder.hs
@@ -433,7 +433,7 @@ instance IsSql92DataTypeSyntax SqlSyntaxBuilder where
     varBitType prec = SqlSyntaxBuilder ("BIT VARYING" <> sqlOptPrec prec)
 
     numericType prec = SqlSyntaxBuilder ("NUMERIC" <> sqlOptNumericPrec prec)
-    decimalType prec = SqlSyntaxBuilder ("DOUBLE" <> sqlOptNumericPrec prec)
+    decimalType prec = SqlSyntaxBuilder ("DECIMAL" <> sqlOptNumericPrec prec)
 
     intType = SqlSyntaxBuilder "INT"
     smallIntType = SqlSyntaxBuilder "SMALLINT"

--- a/beam-postgres/Database/Beam/Postgres/Syntax.hs
+++ b/beam-postgres/Database/Beam/Postgres/Syntax.hs
@@ -541,7 +541,7 @@ instance IsSql92DataTypeSyntax PgDataTypeSyntax where
                                       (emit "NUMERIC" <> pgOptNumericPrec prec)
                                       (numericType prec)
   decimalType prec = PgDataTypeSyntax (PgDataTypeDescrOid (Pg.typoid Pg.numeric) (mkNumericPrec prec))
-                                      (emit "DOUBLE" <> pgOptNumericPrec prec)
+                                      (emit "DECIMAL" <> pgOptNumericPrec prec)
                                       (decimalType prec)
 
   intType = PgDataTypeSyntax (PgDataTypeDescrOid (Pg.typoid Pg.int4) Nothing) (emit "INT") intType

--- a/beam-sqlite/Database/Beam/Sqlite/Syntax.hs
+++ b/beam-sqlite/Database/Beam/Sqlite/Syntax.hs
@@ -521,7 +521,7 @@ instance IsSql92DataTypeSyntax SqliteDataTypeSyntax where
   varBitType prec = SqliteDataTypeSyntax (emit "BIT VARYING" <> sqliteOptPrec prec) (varBitType prec) (varBitType prec) False
 
   numericType prec = SqliteDataTypeSyntax (emit "NUMERIC" <> sqliteOptNumericPrec prec) (numericType prec) (numericType prec) False
-  decimalType prec = SqliteDataTypeSyntax (emit "DOUBLE" <> sqliteOptNumericPrec prec) (decimalType prec) (decimalType prec) False
+  decimalType prec = SqliteDataTypeSyntax (emit "DECIMAL" <> sqliteOptNumericPrec prec) (decimalType prec) (decimalType prec) False
 
   intType = SqliteDataTypeSyntax (emit "INTEGER") intType intType False
   smallIntType = SqliteDataTypeSyntax (emit "SMALLINT") smallIntType smallIntType False


### PR DESCRIPTION
`DOUBLE` is not a valid SQL 92 data type, and Postgres completely rejects it. SQLite would misleadingly accept it with `REAL` affinity instead of `NUMERIC` which is what you might expect if a precision were specified.