### PR TITLE
Bump major version numbers

### DIFF
--- a/beam-core/beam-core.cabal
+++ b/beam-core/beam-core.cabal
@@ -2,7 +2,7 @@
 -- see http://haskell.org/cabal/users-guide/
 
 name:                beam-core
-version:             0.8.1.0
+version:             0.9.0.0
 synopsis:            Type-safe, feature-complete SQL query and manipulation interface for Haskell
 description:         Beam is a Haskell library for type-safe querying and manipulation of SQL databases.
                      Beam is modular and supports various backends. In order to use beam, you will need to use

--- a/beam-migrate-cli/beam-migrate-cli.cabal
+++ b/beam-migrate-cli/beam-migrate-cli.cabal
@@ -28,8 +28,8 @@ executable beam-migrate
                        Database.Beam.Migrate.Tool.Log
                        Database.Beam.Migrate.Tool.Migrate
   build-depends:       base                 >=4.9      && <5.0,
-                       beam-core            >=0.8      && <0.9,
-                       beam-migrate         >=0.4      && <0.5,
+                       beam-core            >=0.9      && <0.10,
+                       beam-migrate         >=0.4      && <0.6,
                        text                 >=1.2      && <1.3,
                        bytestring           >=0.10     && <0.11,
                        time                 >=1.6      && <1.10,

--- a/beam-migrate/beam-migrate.cabal
+++ b/beam-migrate/beam-migrate.cabal
@@ -1,5 +1,5 @@
 name:                beam-migrate
-version:             0.4.0.1
+version:             0.5.0.0
 synopsis:            SQL DDL support and migrations support library for Beam
 description:         This package provides type classes to allow backends to implement
                      SQL DDL support for beam. This allows you to use beam syntax to
@@ -60,7 +60,7 @@ library
                        Database.Beam.Migrate.Types.Predicates
 
   build-depends:       base                 >=4.9     && <5.0,
-                       beam-core            >=0.8     && <0.9,
+                       beam-core            >=0.9     && <0.10,
                        text                 >=1.2     && <1.3,
                        aeson                >=0.11    && <1.5,
                        bytestring           >=0.10    && <0.11,

--- a/beam-postgres/beam-postgres.cabal
+++ b/beam-postgres/beam-postgres.cabal
@@ -1,5 +1,5 @@
 name:                 beam-postgres
-version:              0.4.1.0
+version:              0.5.0.0
 synopsis:             Connection layer between beam and postgres
 description:          Beam driver for <https://www.postgresql.org/ PostgreSQL>, an advanced open-source RDBMS
 homepage:             http://tathougies.github.io/beam/user-guide/backends/beam-postgres
@@ -30,8 +30,8 @@ library
                       Database.Beam.Postgres.Types
 
   build-depends:      base                 >=4.9  && <5.0,
-                      beam-core            >=0.8  && <0.9,
-                      beam-migrate         >=0.4  && <0.5,
+                      beam-core            >=0.9  && <0.10,
+                      beam-migrate         >=0.5  && <0.6,
 
                       postgresql-libpq     >=0.8  && <0.10,
                       postgresql-simple    >=0.5  && <0.7,

--- a/beam-sqlite/beam-sqlite.cabal
+++ b/beam-sqlite/beam-sqlite.cabal
@@ -1,5 +1,5 @@
 name:                beam-sqlite
-version:             0.4.0.0
+version:             0.5.0.0
 synopsis:            Beam driver for SQLite
 description:         Beam driver for the <https://sqlite.org/ SQLite> embedded database.
                      See <http://tathougies.github.io/beam/user-guide/backends/beam-sqlite/ here>
@@ -25,8 +25,8 @@ library
   other-modules:      Database.Beam.Sqlite.SqliteSpecific
   build-depends:      base          >=4.7  && <5,
 
-                      beam-core     >=0.8  && <0.9,
-                      beam-migrate  >=0.4  && <0.5,
+                      beam-core     >=0.9  && <0.10,
+                      beam-migrate  >=0.5  && <0.6,
 
                       sqlite-simple >=0.4  && <0.5,
                       text          >=1.0  && <1.3,


### PR DESCRIPTION
Breaking changes in `beam-core`: #413 (unlikely to break anyone in practice).

Breaking changes in `beam-migrate`: #329.

Breaking changes in `beam-postgres`: #329, #347 and associated PRs.

Breaking changes in `beam-sqlite`: #435.