### PR TITLE
Use newtype for BeamHasInsertOnConflict data family instances

### DIFF
--- a/beam-postgres/Database/Beam/Postgres/Full.hs
+++ b/beam-postgres/Database/Beam/Postgres/Full.hs
@@ -438,9 +438,9 @@ instance PgReturning SqlDelete where
       tblQ = changeBeamRep (\(Columnar' f) -> Columnar' (QExpr . pure . fieldE . unqualifiedField . _fieldName $ f)) tblSettings
 
 instance BeamHasInsertOnConflict Postgres where
-  data SqlConflictTarget Postgres table =
+  newtype SqlConflictTarget Postgres table =
     PgInsertOnConflictTarget (table (QExpr Postgres QInternal) -> PgInsertOnConflictTargetSyntax)
-  data SqlConflictAction Postgres table =
+  newtype SqlConflictAction Postgres table =
     PgConflictAction (table (QField QInternal) -> PgConflictActionSyntax)
 
   insertOnConflict tbl vs target action = insert tbl vs $ onConflict target action

--- a/beam-sqlite/Database/Beam/Sqlite/Connection.hs
+++ b/beam-sqlite/Database/Beam/Sqlite/Connection.hs
@@ -409,9 +409,9 @@ runInsertReturningList (SqlInsert _ insertStmt_@(SqliteInsertSyntax nm _ _ _)) =
            return x
 
 instance Beam.BeamHasInsertOnConflict Sqlite where
-  data SqlConflictTarget Sqlite table = SqliteConflictTarget
+  newtype SqlConflictTarget Sqlite table = SqliteConflictTarget
     { unSqliteConflictTarget :: table (QExpr Sqlite QInternal) -> SqliteSyntax }
-  data SqlConflictAction Sqlite table = SqliteConflictAction
+  newtype SqlConflictAction Sqlite table = SqliteConflictAction
     { unSqliteConflictAction :: forall s. table (QField s) -> SqliteSyntax }
 
   insertOnConflict


### PR DESCRIPTION
When I originally wrote these I believe I was unaware that these can be `newtype`s.