### PR TITLE
Add postgres extensions to database predicates

### DIFF
--- a/beam-postgres/Database/Beam/Postgres/Migrate.hs
+++ b/beam-postgres/Database/Beam/Postgres/Migrate.hs
@@ -373,7 +373,11 @@ getDbConstraintsForSchemas subschemas conn =
      let enumerations =
            map (\(enumNm, _, options) -> Db.SomeDatabasePredicate (PgHasEnum enumNm (V.toList options))) enumerationData
 
-     pure (tblsExist ++ columnChecks ++ primaryKeys ++ enumerations)
+     extensions <-
+       map (\(Pg.Only extname) -> Db.SomeDatabasePredicate (PgHasExtension extname)) <$>
+       Pg.query_ conn "SELECT extname from pg_extension"
+
+     pure (tblsExist ++ columnChecks ++ primaryKeys ++ enumerations ++ extensions)
 
 -- * Postgres-specific data types
 


### PR DESCRIPTION
Currently `verifySchema` doesn't pick up extensions, and thus fails if `CheckedDatabaseSettings` specifies any.