### PR TITLE
Use explicitly sized integer types for Postgres-specific functions

### DIFF
--- a/beam-postgres/Database/Beam/Postgres/PgCrypto.hs
+++ b/beam-postgres/Database/Beam/Postgres/PgCrypto.hs
@@ -11,6 +11,7 @@ import Database.Beam.Backend.SQL
 import Database.Beam.Postgres.Types
 import Database.Beam.Postgres.Extensions
 
+import Data.Int
 import Data.Text (Text)
 import Data.ByteString (ByteString)
 import Data.Vector (Vector)
@@ -41,7 +42,7 @@ data PgCrypto
   , pgCryptoCrypt ::
       forall ctxt s. LiftPg ctxt s (Text -> Text -> Text)
   , pgCryptoGenSalt ::
-      forall ctxt s. LiftPg ctxt s (Text -> Maybe Int -> Text)
+      forall ctxt s. LiftPg ctxt s (Text -> Maybe Int32 -> Text)
 
   -- Pgp functions
   , pgCryptoPgpSymEncrypt ::


### PR DESCRIPTION
This is the first step of #496.

Relevant documentation:

 * `UNNEST ... WITH ORDINALITY`: https://www.postgresql.org/docs/12/queries-table-expressions.html
 * JSON functions: https://www.postgresql.org/docs/current/functions-json.html
 * pgcrypto: https://www.postgresql.org/docs/current/pgcrypto.html