### PR TITLE
Use Integral for SQL Int values in beam-core

### DIFF
--- a/beam-core/Database/Beam/Query/Aggregate.hs
+++ b/beam-core/Database/Beam/Query/Aggregate.hs
@@ -174,7 +174,7 @@ sum_ :: ( BeamSqlBackend be, Num a )
 sum_ = sumOver_ allInGroup_
 
 -- | SQL @COUNT(*)@ function
-countAll_ :: BeamSqlBackend be => QAgg be s Int
+countAll_ :: ( BeamSqlBackend be, Integral a ) => QAgg be s a
 countAll_ = QExpr (pure countAllE)
 
 -- | SQL @COUNT(ALL ..)@ function (but without the explicit ALL)
@@ -193,18 +193,18 @@ percentRank_ :: BeamSqlT612Backend be
 percentRank_ = QExpr (pure percentRankAggE)
 
 -- | SQL2003 @DENSE_RANK@ function (Requires T612 Advanced OLAP operations support)
-denseRank_ :: BeamSqlT612Backend be
-           => QAgg be s Int
+denseRank_ :: ( BeamSqlT612Backend be, Integral a )
+           => QAgg be s a
 denseRank_ = QExpr (pure denseRankAggE)
 
 -- | SQL2003 @ROW_NUMBER@ function
-rowNumber_ :: BeamSql2003ExpressionBackend be
-           =>  QAgg be s Int
+rowNumber_ :: ( BeamSql2003ExpressionBackend be, Integral a )
+           =>  QAgg be s a
 rowNumber_ = QExpr (pure rowNumberE)
 
 -- | SQL2003 @RANK@ function (Requires T611 Elementary OLAP operations support)
-rank_ :: BeamSqlT611Backend be
-      => QAgg be s Int
+rank_ :: ( BeamSqlT611Backend be, Integral a )
+      => QAgg be s a
 rank_ = QExpr (pure rankAggE)
 
 minOver_, maxOver_

--- a/beam-core/Database/Beam/Query/Combinators.hs
+++ b/beam-core/Database/Beam/Query/Combinators.hs
@@ -85,6 +85,7 @@ import Control.Monad.Writer hiding ((<>))
 import Data.Semigroup
 #endif
 
+import Data.Int
 import Data.Maybe
 import Data.Proxy
 import Data.Time (LocalTime)
@@ -360,18 +361,18 @@ subquery_ q =
   QExpr (\tbl -> subqueryE (buildSqlQuery tbl q))
 
 -- | SQL @CHAR_LENGTH@ function
-charLength_ :: ( BeamSqlBackend be, BeamSqlBackendIsString be text )
-            => QGenExpr context be s text -> QGenExpr context be s Int
+charLength_ :: ( BeamSqlBackend be, BeamSqlBackendIsString be text, Integral a )
+            => QGenExpr context be s text -> QGenExpr context be s a
 charLength_ (QExpr s) = QExpr (charLengthE <$> s)
 
 -- | SQL @OCTET_LENGTH@ function
-octetLength_ :: ( BeamSqlBackend be, BeamSqlBackendIsString be text )
-             => QGenExpr context be s text -> QGenExpr context be s Int
+octetLength_ :: ( BeamSqlBackend be, BeamSqlBackendIsString be text, Integral a )
+             => QGenExpr context be s text -> QGenExpr context be s a
 octetLength_ (QExpr s) = QExpr (octetLengthE <$> s)
 
 -- | SQL @BIT_LENGTH@ function
-bitLength_ :: BeamSqlBackend be
-           => QGenExpr context be s SqlBitString -> QGenExpr context be s Int
+bitLength_ :: ( BeamSqlBackend be, Integral a )
+           => QGenExpr context be s SqlBitString -> QGenExpr context be s a
 bitLength_ (QExpr x) = QExpr (bitLengthE <$> x)
 
 -- | SQL @CURRENT_TIMESTAMP@ function
@@ -513,7 +514,7 @@ exceptAll_ (Q a) (Q b) = Q (liftF (QSetOp (exceptTable True) a b (rewriteThread 
 --
 --   But this is not
 --
--- > aggregate_ (\_ -> as_ @Int countAll_) ..
+-- > aggregate_ (\_ -> as_ @Int32 countAll_) ..
 --
 as_ :: forall a ctxt be s. QGenExpr ctxt be s a -> QGenExpr ctxt be s a
 as_ = id
@@ -586,10 +587,10 @@ nrows_ :: BeamSql2003ExpressionBackend be
        => Int -> QFrameBound be
 nrows_ x = QFrameBound (nrowsBoundSyntax x)
 
-noPartition_ :: Maybe (QExpr be s Int)
+noPartition_ :: Integral a => Maybe (QExpr be s a)
 noPartition_ = Nothing
 
-noOrder_ :: Maybe (QOrd be s Int)
+noOrder_ :: Integral a => Maybe (QOrd be s a)
 noOrder_ = Nothing
 
 partitionBy_, orderPartitionBy_ :: partition -> Maybe partition

--- a/beam-core/Database/Beam/Query/Extensions.hs
+++ b/beam-core/Database/Beam/Query/Extensions.hs
@@ -41,8 +41,8 @@ import Database.Beam.Query.Aggregate
 
 import Database.Beam.Backend.SQL
 
-ntile_ :: (BeamSqlBackend be, BeamSqlT614Backend be)
-       => QExpr be s Int -> QAgg be s a
+ntile_ :: (BeamSqlBackend be, BeamSqlT614Backend be, Integral n)
+       => QExpr be s n -> QAgg be s a
 ntile_ (QExpr a) = QExpr (ntileE <$> a)
 
 lead1_, lag1_
@@ -52,14 +52,14 @@ lead1_ (QExpr a) = QExpr (leadE <$> a <*> pure Nothing <*> pure Nothing)
 lag1_ (QExpr a) = QExpr (lagE <$> a <*> pure Nothing <*> pure Nothing)
 
 lead_, lag_
-  :: (BeamSqlBackend be, BeamSqlT615Backend be)
-  => QExpr be s a -> QExpr be s Int -> QAgg be s a
+  :: (BeamSqlBackend be, BeamSqlT615Backend be, Integral n)
+  => QExpr be s a -> QExpr be s n -> QAgg be s a
 lead_ (QExpr a) (QExpr n) = QExpr (leadE <$> a <*> (Just <$> n) <*> pure Nothing)
 lag_ (QExpr a) (QExpr n) = QExpr (lagE <$> a <*> (Just <$> n) <*> pure Nothing)
 
 leadWithDefault_, lagWithDefault_
-  :: (BeamSqlBackend be, BeamSqlT615Backend be)
-  => QExpr be s a -> QExpr be s Int -> QExpr be s a
+  :: (BeamSqlBackend be, BeamSqlT615Backend be, Integral n)
+  => QExpr be s a -> QExpr be s n -> QExpr be s a
   -> QAgg be s a
 leadWithDefault_ (QExpr a) (QExpr n) (QExpr def) =
   QExpr (leadE <$> a <*> fmap Just n <*> fmap Just def)
@@ -75,8 +75,8 @@ lastValue_ (QExpr a) = QExpr (lastValueE <$> a)
 
 -- TODO see comment for 'firstValue_' and 'lastValue_'
 nthValue_
-  :: (BeamSqlBackend be, BeamSqlT618Backend be)
-  => QExpr be s a -> QExpr be s Int -> QAgg be s a
+  :: (BeamSqlBackend be, BeamSqlT618Backend be, Integral n)
+  => QExpr be s a -> QExpr be s n -> QAgg be s a
 nthValue_ (QExpr a) (QExpr n) = QExpr (nthValueE <$> a <*> n)
 
 ln_, exp_, sqrt_


### PR DESCRIPTION
This should remove all SQL-internal uses of `Int` in beam-core (#496). Rather than introducing a type family for the cardinality type for a backend, I extended the existing pattern of using `Integral`, even though it's in general less safe.