### PR TITLE
Add Postgres extension definition for uuid-ossp

### DIFF
--- a/beam-postgres/Database/Beam/Postgres/Extensions/Internal.hs
+++ b/beam-postgres/Database/Beam/Postgres/Extensions/Internal.hs
@@ -1,0 +1,17 @@
+module Database.Beam.Postgres.Extensions.Internal where
+
+import Data.Text (Text)
+
+import Database.Beam
+import Database.Beam.Backend.SQL
+import Database.Beam.Postgres
+
+type PgExpr ctxt s = QGenExpr ctxt Postgres s
+
+type family LiftPg ctxt s fn where
+  LiftPg ctxt s (Maybe a -> b) = Maybe (PgExpr ctxt s a) -> LiftPg ctxt s b
+  LiftPg ctxt s (a -> b) = PgExpr ctxt s a -> LiftPg ctxt s b
+  LiftPg ctxt s a = PgExpr ctxt s a
+
+funcE :: IsSql99ExpressionSyntax expr => Text -> [expr] -> expr
+funcE nm args = functionCallE (fieldE (unqualifiedField nm)) args

--- a/beam-postgres/Database/Beam/Postgres/Extensions/UuidOssp.hs
+++ b/beam-postgres/Database/Beam/Postgres/Extensions/UuidOssp.hs
@@ -1,0 +1,63 @@
+-- | The @uuid-ossp@ extension provides functions for constructing UUIDs.
+--
+-- For an example of usage, see the documentation for 'PgExtensionEntity'.
+module Database.Beam.Postgres.Extensions.UuidOssp
+  ( UuidOssp(..)
+  ) where
+
+import           Data.Proxy (Proxy(..))
+import           Data.Text (Text)
+import           Data.UUID.Types (UUID)
+
+import           Database.Beam
+import           Database.Beam.Postgres.Extensions
+import           Database.Beam.Postgres.Extensions.Internal
+
+-- | Data type representing definitions contained in the @uuid-ossp@ extension
+data UuidOssp = UuidOssp
+  { pgUuidNil ::
+      forall ctxt s. LiftPg ctxt s UUID
+  , pgUuidNsDns ::
+      forall ctxt s. LiftPg ctxt s UUID
+  , pgUuidNsUrl ::
+      forall ctxt s. LiftPg ctxt s UUID
+  , pgUuidNsOid ::
+      forall ctxt s. LiftPg ctxt s UUID
+  , pgUuidNsX500 ::
+      forall ctxt s. LiftPg ctxt s UUID
+  , pgUuidGenerateV1 ::
+      forall ctxt s. LiftPg ctxt s UUID
+  , pgUuidGenerateV1Mc ::
+      forall ctxt s. LiftPg ctxt s UUID
+  , pgUuidGenerateV3 ::
+      forall ctxt s. LiftPg ctxt s (UUID -> Text -> UUID)
+  , pgUuidGenerateV4 ::
+      forall ctxt s. LiftPg ctxt s UUID
+  , pgUuidGenerateV5 ::
+      forall ctxt s. LiftPg ctxt s (UUID -> Text -> UUID)
+  }
+
+instance IsPgExtension UuidOssp where
+  pgExtensionName Proxy = "uuid-ossp"
+  pgExtensionBuild = UuidOssp
+    { pgUuidNil =
+        QExpr $ funcE "uuid_nil" <$> sequenceA []
+    , pgUuidNsDns =
+        QExpr $ funcE "uuid_ns_dns" <$> sequenceA []
+    , pgUuidNsUrl =
+        QExpr $ funcE "uuid_ns_url" <$> sequenceA []
+    , pgUuidNsOid =
+        QExpr $ funcE "uuid_ns_oid" <$> sequenceA []
+    , pgUuidNsX500 =
+        QExpr $ funcE "uuid_ns_x500" <$> sequenceA []
+    , pgUuidGenerateV1 =
+        QExpr $ funcE "uuid_generate_v1" <$> sequenceA []
+    , pgUuidGenerateV1Mc =
+        QExpr $ funcE "uuid_generate_v1mc" <$> sequenceA []
+    , pgUuidGenerateV3 = \(QExpr ns) (QExpr t) ->
+        QExpr $ funcE "uuid_generate_v3" <$> sequenceA [ns, t]
+    , pgUuidGenerateV4 =
+        QExpr $ funcE "uuid_generate_v4" <$> sequenceA []
+    , pgUuidGenerateV5 = \(QExpr ns) (QExpr t) ->
+        QExpr $ funcE "uuid_generate_v5" <$> sequenceA [ns, t]
+    }

--- a/beam-postgres/Database/Beam/Postgres/PgCrypto.hs
+++ b/beam-postgres/Database/Beam/Postgres/PgCrypto.hs
@@ -1,3 +1,4 @@
+
 -- | The @pgcrypto@ extension provides several cryptographic functions to
 -- Postgres. This module provides a @beam-postgres@ extension to access this
 -- functionality. For an example of usage, see the documentation for
@@ -8,21 +9,14 @@ module Database.Beam.Postgres.PgCrypto
 import Database.Beam
 import Database.Beam.Backend.SQL
 
-import Database.Beam.Postgres.Types
 import Database.Beam.Postgres.Extensions
+import Database.Beam.Postgres.Extensions.Internal
 
 import Data.Int
 import Data.Text (Text)
 import Data.ByteString (ByteString)
 import Data.Vector (Vector)
 import Data.UUID.Types (UUID)
-
-type PgExpr ctxt s = QGenExpr ctxt Postgres s
-
-type family LiftPg ctxt s fn where
-  LiftPg ctxt s (Maybe a -> b) = Maybe (PgExpr ctxt s a) -> LiftPg ctxt s b
-  LiftPg ctxt s (a -> b) = PgExpr ctxt s a -> LiftPg ctxt s b
-  LiftPg ctxt s a = PgExpr ctxt s a
 
 -- | Data type representing definitions contained in the @pgcrypto@ extension
 --
@@ -84,9 +78,6 @@ data PgCrypto
   , pgCryptoGenRandomUUID ::
       forall ctxt s. PgExpr ctxt s UUID
   }
-
-funcE :: IsSql99ExpressionSyntax expr => Text -> [expr] -> expr
-funcE nm args = functionCallE (fieldE (unqualifiedField nm)) args
 
 instance IsPgExtension PgCrypto where
   pgExtensionName _ = "pgcrypto"

--- a/beam-postgres/beam-postgres.cabal
+++ b/beam-postgres/beam-postgres.cabal
@@ -16,16 +16,19 @@ bug-reports:          https://github.com/haskell-beam/beam/issues
 library
   exposed-modules:    Database.Beam.Postgres
                       Database.Beam.Postgres.Migrate
-                      Database.Beam.Postgres.PgCrypto
                       Database.Beam.Postgres.Syntax
                       Database.Beam.Postgres.CustomTypes
 
                       Database.Beam.Postgres.Conduit
                       Database.Beam.Postgres.Full
 
+                      Database.Beam.Postgres.PgCrypto
+                      Database.Beam.Postgres.Extensions.UuidOssp
+
   other-modules:      Database.Beam.Postgres.Connection
                       Database.Beam.Postgres.Debug
                       Database.Beam.Postgres.Extensions
+                      Database.Beam.Postgres.Extensions.Internal
                       Database.Beam.Postgres.PgSpecific
                       Database.Beam.Postgres.Types
 

--- a/beam-postgres/test/Database/Beam/Postgres/Test/Select.hs
+++ b/beam-postgres/test/Database/Beam/Postgres/Test/Select.hs
@@ -3,25 +3,65 @@ module Database.Beam.Postgres.Test.Select (tests) where
 import           Data.Aeson
 import           Data.ByteString (ByteString)
 import           Data.Int
+import           Data.Text (Text)
 import qualified Data.Vector as V
 import           Test.Tasty
 import           Test.Tasty.HUnit
+import           Data.UUID (UUID, nil)
 
 import           Database.Beam
+import           Database.Beam.Migrate
 import           Database.Beam.Postgres
+import           Database.Beam.Postgres.Extensions.UuidOssp
 
 import           Database.Beam.Postgres.Test
 
 tests :: IO ByteString -> TestTree
 tests getConn = testGroup "Selection Tests"
-  [ testPgArrayToJSON getConn
+  [ testGroup "JSON"
+      [ testPgArrayToJSON getConn
+      ]
+  , testGroup "UUID"
+      [ testUuidFunction getConn "uuid_nil" pgUuidNil
+      , testUuidFunction getConn "uuid_ns_dns" pgUuidNsDns
+      , testUuidFunction getConn "uuid_ns_url" pgUuidNsUrl
+      , testUuidFunction getConn "uuid_ns_oid" pgUuidNsOid
+      , testUuidFunction getConn "uuid_ns_x500" pgUuidNsX500
+      , testUuidFunction getConn "uuid_generate_v1" pgUuidGenerateV1
+      , testUuidFunction getConn "uuid_generate_v1mc" pgUuidGenerateV1Mc
+      , testUuidFunction getConn "uuid_generate_v3" $ \ext ->
+          pgUuidGenerateV3 ext (val_ nil) "nil"
+      , testUuidFunction getConn "uuid_generate_v4" pgUuidGenerateV4
+      , testUuidFunction getConn "uuid_generate_v5" $ \ext ->
+          pgUuidGenerateV5 ext (val_ nil) "nil"
+      ]
   ]
 
 testPgArrayToJSON :: IO ByteString -> TestTree
-testPgArrayToJSON getConn = testCase "array_to_json" $
-  withTestPostgres "array_to_json" getConn $ \conn -> do
-    let values :: [Int32] = [1, 2, 3]
-    actual :: [PgJSON Value] <-
-      runBeamPostgres conn $ runSelectReturningList $ select $
-        return $ pgArrayToJson $ val_ $ V.fromList values
-    assertEqual "JSON list" [PgJSON $ toJSON values] actual
+testPgArrayToJSON getConn = testFunction getConn "array_to_json" $ \conn -> do
+  let values :: [Int32] = [1, 2, 3]
+  actual :: [PgJSON Value] <-
+    runBeamPostgres conn $ runSelectReturningList $ select $
+      return $ pgArrayToJson $ val_ $ V.fromList values
+  assertEqual "JSON list" [PgJSON $ toJSON values] actual
+
+data UuidSchema f = UuidSchema
+  { _uuidOssp :: f (PgExtensionEntity UuidOssp)
+  } deriving (Generic, Database Postgres)
+
+testUuidFunction
+  :: IO ByteString
+  -> String
+  -> (forall s. UuidOssp -> QExpr Postgres s UUID)
+  -> TestTree
+testUuidFunction getConn name mkUuid = testFunction getConn name $ \conn ->
+  runBeamPostgres conn $ do
+    db <- executeMigration runNoReturn $ UuidSchema <$>
+      pgCreateExtension @UuidOssp
+    [_] <- runSelectReturningList $ select $
+      return $ mkUuid $ getPgExtension $ _uuidOssp $ unCheckDatabase db
+    return ()
+
+testFunction :: IO ByteString -> String -> (Connection -> Assertion) -> TestTree
+testFunction getConn name mkAssertion = testCase name $
+  withTestPostgres name getConn mkAssertion


### PR DESCRIPTION
As of #488 extensions are picked up by `backendGetDbConstraints`, so it becomes more useful to have them predefined.