### PR TITLE
Remove instances for ambiguously sized integers

### DIFF
--- a/beam-core/Database/Beam/Backend/Internal/Compat.hs
+++ b/beam-core/Database/Beam/Backend/Internal/Compat.hs
@@ -1,0 +1,16 @@
+-- | This module contains utilities that backend writers can use to assist with
+-- compatibility and breaking API changes.
+--
+-- Users should not need anything from this module.
+module Database.Beam.Backend.Internal.Compat where
+
+import GHC.TypeLits
+
+-- | A type error directing the user to use an explicitly sized integers,
+-- instead of 'Int' or 'Word'.
+type PreferExplicitSize implicit explicit =
+  'Text "The size of " ':<>:
+  'ShowType implicit ':<>:
+  'Text " is machine-dependent. Use an explicitly sized integer such as " ':<>:
+  'ShowType explicit ':<>:
+  'Text " instead."

--- a/beam-core/Database/Beam/Backend/SQL/AST.hs
+++ b/beam-core/Database/Beam/Backend/SQL/AST.hs
@@ -6,6 +6,7 @@ module Database.Beam.Backend.SQL.AST where
 
 import Prelude hiding (Ordering)
 
+import Database.Beam.Backend.Internal.Compat
 import Database.Beam.Backend.SQL.SQL92
 import Database.Beam.Backend.SQL.SQL99
 import Database.Beam.Backend.SQL.SQL2003
@@ -17,6 +18,7 @@ import Data.Time
 import Data.Word (Word16, Word32, Word64)
 import Data.Typeable
 import Data.Int
+import GHC.TypeLits
 
 data Command
   = SelectCommand Select
@@ -502,11 +504,9 @@ data Value where
   Value :: (Show a, Eq a, Typeable a) => a -> Value
 
 #define VALUE_SYNTAX_INSTANCE(ty) instance HasSqlValueSyntax Value ty where { sqlValueSyntax = Value }
-VALUE_SYNTAX_INSTANCE(Int)
 VALUE_SYNTAX_INSTANCE(Int16)
 VALUE_SYNTAX_INSTANCE(Int32)
 VALUE_SYNTAX_INSTANCE(Int64)
-VALUE_SYNTAX_INSTANCE(Word)
 VALUE_SYNTAX_INSTANCE(Word16)
 VALUE_SYNTAX_INSTANCE(Word32)
 VALUE_SYNTAX_INSTANCE(Word64)
@@ -521,6 +521,12 @@ VALUE_SYNTAX_INSTANCE(TimeOfDay)
 VALUE_SYNTAX_INSTANCE(SqlNull)
 VALUE_SYNTAX_INSTANCE(Double)
 VALUE_SYNTAX_INSTANCE(Bool)
+
+instance TypeError (PreferExplicitSize Int Int32) => HasSqlValueSyntax Value Int where
+  sqlValueSyntax = Value
+
+instance TypeError (PreferExplicitSize Word Word32) => HasSqlValueSyntax Value Word where
+  sqlValueSyntax = Value
 
 instance HasSqlValueSyntax Value x => HasSqlValueSyntax Value (Maybe x) where
   sqlValueSyntax (Just x) = sqlValueSyntax x

--- a/beam-core/Database/Beam/Backend/SQL/SQL92.hs
+++ b/beam-core/Database/Beam/Backend/SQL/SQL92.hs
@@ -71,7 +71,7 @@ type Sql92SanityCheck cmd =
   )
 
 type Sql92ReasonableMarshaller be =
-   ( FromBackendRow be Int, FromBackendRow be SqlNull
+   ( FromBackendRow be SqlNull
    , FromBackendRow be Text, FromBackendRow be Bool
    , FromBackendRow be Char
    , FromBackendRow be Int16, FromBackendRow be Int32, FromBackendRow be Int64
@@ -229,7 +229,7 @@ class IsSql92DataTypeSyntax dataType where
   timestampType :: Maybe Word -> Bool {-^ With time zone -} -> dataType
   -- TODO interval type
 
-class ( HasSqlValueSyntax (Sql92ExpressionValueSyntax expr) Int
+class ( HasSqlValueSyntax (Sql92ExpressionValueSyntax expr) Int32
       , HasSqlValueSyntax (Sql92ExpressionValueSyntax expr) Bool
       , IsSql92FieldNameSyntax (Sql92ExpressionFieldNameSyntax expr)
       , IsSql92QuantifierSyntax (Sql92ExpressionQuantifierSyntax expr)

--- a/beam-core/Database/Beam/Query/Combinators.hs
+++ b/beam-core/Database/Beam/Query/Combinators.hs
@@ -85,7 +85,6 @@ import Control.Monad.Writer hiding ((<>))
 import Data.Semigroup
 #endif
 
-import Data.Int
 import Data.Maybe
 import Data.Proxy
 import Data.Time (LocalTime)

--- a/beam-core/Database/Beam/Query/CustomSQL.hs
+++ b/beam-core/Database/Beam/Query/CustomSQL.hs
@@ -20,10 +20,10 @@
 --
 --   The returned function is polymorphic in the types of SQL expressions it
 --   will accept, but you can give it a more specific signature. For example, to
---   mandate that we receive two 'Int's and a 'T.Text' and return a 'Bool'.
+--   mandate that we receive two 'Int32's and a 'T.Text' and return a 'Bool'.
 --
 -- @
--- myFunc_ :: QGenExpr e ctxt s Int -> QGenExpr e ctxt s Int -> QGenExpr e ctxt s T.Text -> QGenExpr e ctxt s Bool
+-- myFunc_ :: QGenExpr e ctxt s Int32 -> QGenExpr e ctxt s Int32 -> QGenExpr e ctxt s T.Text -> QGenExpr e ctxt s Bool
 -- myFunc_ = customExpr_ myFuncImpl
 -- @
 --

--- a/beam-core/beam-core.cabal
+++ b/beam-core/beam-core.cabal
@@ -47,6 +47,9 @@ library
                        Database.Beam.Backend.SQL.SQL2003
                        Database.Beam.Backend.SQL.Builder
                        Database.Beam.Backend.SQL.AST
+
+                       Database.Beam.Backend.Internal.Compat
+
   other-modules:       Database.Beam.Query.Aggregate
                        Database.Beam.Query.Combinators
                        Database.Beam.Query.Extensions
@@ -56,6 +59,7 @@ library
                        Database.Beam.Query.Relationships
 
                        Database.Beam.Schema.Lenses
+
   build-depends:       base         >=4.9     && <5.0,
                        aeson        >=0.11    && <1.5,
                        text         >=1.2.2.0 && <1.3,

--- a/beam-core/test/Database/Beam/Test/SQL.hs
+++ b/beam-core/test/Database/Beam/Test/SQL.hs
@@ -113,7 +113,7 @@ simpleWhere =
      Just (FromTable (TableNamed (TableName Nothing "employees")) (Just (employees, Nothing))) <- pure selectFrom
 
      let salaryCond = ExpressionCompOp ">" Nothing (ExpressionFieldName (QualifiedField employees "salary")) (ExpressionValue (Value (120202 :: Double)))
-         ageCond = ExpressionCompOp "<" Nothing (ExpressionFieldName (QualifiedField employees "age")) (ExpressionValue (Value (30 :: Int)))
+         ageCond = ExpressionCompOp "<" Nothing (ExpressionFieldName (QualifiedField employees "age")) (ExpressionValue (Value (30 :: Int32)))
          nameCond = ExpressionCompOp "==" Nothing (ExpressionFieldName (QualifiedField employees "first_name")) (ExpressionFieldName (QualifiedField employees "last_name"))
 
      selectWhere @?= Just (ExpressionBinOp "AND" salaryCond (ExpressionBinOp "AND" ageCond nameCond))
@@ -913,7 +913,7 @@ selectCombinators =
 
     fieldNamesCapturedCorrectly =
       testCase "UNION field names are propagated correctly" $
-      do let -- leaveDates, hireDates :: Q _ _ s ( QExpr Expression s Text, QExpr Expression s Int, QExpr Expression s (Maybe _) )
+      do let -- leaveDates, hireDates :: Q _ _ s ( QExpr Expression s Text, QExpr Expression s Int32, QExpr Expression s (Maybe _) )
              hireDates = do e <- all_ (_employees employeeDbSettings)
                             pure (as_ @Text $ val_ "hire", _employeeAge e, just_ (_employeeHireDate e))
              leaveDates = do e <- all_ (_employees employeeDbSettings)
@@ -928,11 +928,11 @@ selectCombinators =
          Just (FromTable (TableFromSubSelect subselect) (Just (subselectTbl, Nothing))) <- pure selectFrom
          selectProjection @?= ProjExprs [ (ExpressionFieldName (QualifiedField subselectTbl "res0"), Just "res0")
                                         , (ExpressionBinOp "+" (ExpressionFieldName (QualifiedField subselectTbl "res1"))
-                                                               (ExpressionValue (Value (23 :: Int))), Just "res1")
+                                                               (ExpressionValue (Value (23 :: Int32))), Just "res1")
                                         , (ExpressionFieldName (QualifiedField subselectTbl "res2"), Just "res2") ]
          selectHaving @?= Nothing
          selectGrouping @?= Nothing
-         selectWhere @?= Just (ExpressionCompOp "<" Nothing (ExpressionFieldName (QualifiedField subselectTbl "res1")) (ExpressionValue (Value (22 :: Int))))
+         selectWhere @?= Just (ExpressionCompOp "<" Nothing (ExpressionFieldName (QualifiedField subselectTbl "res1")) (ExpressionValue (Value (22 :: Int32))))
 
          Select { selectTable = UnionTables False hireDatesQuery leaveDatesQuery
                 , selectLimit = Just 10, selectOffset = Nothing
@@ -976,7 +976,7 @@ selectCombinators =
 
     equalProjectionsDontHaveSubSelects =
       testCase "Equal projections dont have sub-selects" $
-      do let -- leaveDates, hireDates :: Q _ _ s ( QExpr Expression s Text, QExpr Expression s Text, QExpr Expression s Int )
+      do let -- leaveDates, hireDates :: Q _ _ s ( QExpr Expression s Text, QExpr Expression s Text, QExpr Expression s Int32 )
              hireDates = do e <- all_ (_employees employeeDbSettings)
                             pure (_employeeFirstName e, _employeeLastName e, _employeeAge e)
              leaveDates = do e <- all_ (_employees employeeDbSettings)
@@ -990,7 +990,7 @@ selectCombinators =
 
     unionWithGuards =
       testCase "UNION with guards" $
-      do let -- leaveDates, hireDates :: Q _ _ s ( QExpr Expression s Text, QExpr Expression s Int, QExpr Expression s (Maybe _) )
+      do let -- leaveDates, hireDates :: Q _ _ s ( QExpr Expression s Text, QExpr Expression s Int32, QExpr Expression s (Maybe _) )
              hireDates = do e <- all_ (_employees employeeDbSettings)
                             pure (as_ @Text $ val_ "hire", _employeeAge e, just_ (_employeeHireDate e))
              leaveDates = do e <- all_ (_employees employeeDbSettings)
@@ -1023,7 +1023,7 @@ selectCombinators =
          proj @?= ProjExprs [ ( ExpressionFieldName (QualifiedField t0 "res0"), Just "res0" )
                             , ( ExpressionFieldName (QualifiedField t0 "res1"), Just "res1" )
                             , ( ExpressionFieldName (QualifiedField t0 "res2"), Just "res2" ) ]
-         where_ @?= ExpressionCompOp "<" Nothing (ExpressionFieldName (QualifiedField "t0" "res1")) (ExpressionValue (Value (40 :: Int)))
+         where_ @?= ExpressionCompOp "<" Nothing (ExpressionFieldName (QualifiedField "t0" "res1")) (ExpressionValue (Value (40 :: Int32)))
          pure ()
 
 
@@ -1077,7 +1077,7 @@ limitOffset =
                                           , (ExpressionFieldName (QualifiedField "t0" "leave_date"), Just "res6")
                                           , (ExpressionFieldName (QualifiedField "t0" "created"), Just "res7") ]
          selectFrom a @?= Just (FromTable (TableNamed (TableName Nothing "employees")) (Just ("t0", Nothing)))
-         selectWhere a @?= Just (ExpressionCompOp "<" Nothing (ExpressionFieldName (QualifiedField "t0" "age")) (ExpressionValue (Value (40 :: Int))))
+         selectWhere a @?= Just (ExpressionCompOp "<" Nothing (ExpressionFieldName (QualifiedField "t0" "age")) (ExpressionValue (Value (40 :: Int32))))
          selectGrouping a @?= Nothing
          selectHaving a @?= Nothing
 
@@ -1090,7 +1090,7 @@ limitOffset =
                                           , (ExpressionFieldName (QualifiedField "t0" "leave_date"), Just "res6")
                                           , (ExpressionFieldName (QualifiedField "t0" "created"), Just "res7") ]
          selectFrom b @?= Just (FromTable (TableNamed (TableName Nothing "employees")) (Just ("t0", Nothing)))
-         selectWhere b @?= Just (ExpressionCompOp ">" Nothing (ExpressionFieldName (QualifiedField "t0" "age")) (ExpressionValue (Value (50 :: Int))))
+         selectWhere b @?= Just (ExpressionCompOp ">" Nothing (ExpressionFieldName (QualifiedField "t0" "age")) (ExpressionValue (Value (50 :: Int32))))
          selectGrouping b @?= Nothing
          selectHaving b @?= Nothing
 
@@ -1110,7 +1110,7 @@ existsTest =
              role <- all_ (_roles employeeDbSettings)
              guard_ (not_ (exists_ (do dept <- all_ (_departments employeeDbSettings)
                                        guard_ (_departmentName dept ==. _roleName role)
-                                       pure (as_ @Int 1))))
+                                       pure (as_ @Int32 1))))
              pure role
 
          let existsQuery = Select
@@ -1118,7 +1118,7 @@ existsTest =
                          , selectOrdering = []
                          , selectTable = SelectTable
                                        { selectQuantifier = Nothing
-                                       , selectProjection = ProjExprs [ (ExpressionValue (Value (1 :: Int)), Just "res0") ]
+                                       , selectProjection = ProjExprs [ (ExpressionValue (Value (1 :: Int32)), Just "res0") ]
                                        , selectGrouping = Nothing
                                        , selectHaving = Nothing
                                        , selectWhere = Just joinExpr
@@ -1143,7 +1143,7 @@ updateCurrent =
                          (\employee -> _employeeFirstName employee ==. "Joe")
 
      updateTable @?= (TableName Nothing "employees")
-     updateFields @?= [ (UnqualifiedField "age", ExpressionBinOp "+" (ExpressionFieldName (UnqualifiedField "age")) (ExpressionValue (Value (1 :: Int)))) ]
+     updateFields @?= [ (UnqualifiedField "age", ExpressionBinOp "+" (ExpressionFieldName (UnqualifiedField "age")) (ExpressionValue (Value (1 :: Int32)))) ]
      updateWhere @?= Just (ExpressionCompOp "==" Nothing (ExpressionFieldName (UnqualifiedField "first_name")) (ExpressionValue (Value ("Joe" :: String))))
 
 updateNullable :: TestTree

--- a/beam-core/test/Database/Beam/Test/Schema.hs
+++ b/beam-core/test/Database/Beam/Test/Schema.hs
@@ -17,6 +17,7 @@ import           Database.Beam
 import           Database.Beam.Schema.Tables
 import           Database.Beam.Backend
 
+import           Data.Int
 import           Data.List.NonEmpty ( NonEmpty((:|)) )
 import           Data.Text (Text)
 import qualified Data.Text as T
@@ -49,7 +50,7 @@ data EmployeeT f
   , _employeeLastName  :: Columnar f Text
   , _employeePhoneNumber :: Columnar f Text
 
-  , _employeeAge       :: Columnar f Int
+  , _employeeAge       :: Columnar f Int32
   , _employeeSalary    :: Columnar f Double
 
   , _employeeHireDate  :: Columnar f UTCTime
@@ -146,7 +147,7 @@ data FunnyT f
   , funny_first_name :: Columnar f Text
   , _funny_lastName :: Columnar f Text
   , _funny_middle_Name :: Columnar f Text
-  , ___ :: Columnar f Int }
+  , ___ :: Columnar f Int32 }
   deriving Generic
 instance Beamable FunnyT
 instance Table FunnyT where
@@ -247,7 +248,7 @@ instance (Table metaInfo, Table prop) => Beamable (PrimaryKey (DepartamentRelate
 data VehiculeT f = VehiculeT
       { _vehiculeId     :: C f Text
       , _vehiculeType   :: C f Text
-      , _numberOfWheels :: C f Int
+      , _numberOfWheels :: C f Int32
       } deriving Generic
 
 instance Beamable VehiculeT

--- a/beam-migrate/Database/Beam/Haskell/Syntax.hs
+++ b/beam-migrate/Database/Beam/Haskell/Syntax.hs
@@ -23,6 +23,7 @@ import           Database.Beam.Migrate.Serialization
 
 import           Data.Char (toLower, toUpper)
 import           Data.Hashable
+import           Data.Int
 import           Data.List (find, nub)
 import qualified Data.Map as M
 import           Data.Maybe
@@ -717,7 +718,7 @@ instance IsSql92ConstraintAttributesSyntax HsNone where
   notDeferrableAttributeSyntax = HsNone
   deferrableAttributeSyntax = HsNone
 
-instance HasSqlValueSyntax HsExpr Int where
+instance HasSqlValueSyntax HsExpr Int32 where
   sqlValueSyntax = hsInt
 instance HasSqlValueSyntax HsExpr Bool where
   sqlValueSyntax True = hsVar "True"

--- a/beam-migrate/Database/Beam/Migrate/Simple.hs
+++ b/beam-migrate/Database/Beam/Migrate/Simple.hs
@@ -128,9 +128,9 @@ bringUpToDateWithHooks hooks be@(BeamMigrationBackend { backendRenderSyntax = re
            case log of
              [] -> pure ()
              LogEntry actId actStepNm _:log'
-               | actId == stepIx && actStepNm == stepNm ->
+               | fromIntegral actId == stepIx && actStepNm == stepNm ->
                    tell (Max stepIx) >> put log'
-               | actId /= stepIx ->
+               | fromIntegral actId /= stepIx ->
                    lift . lift $ discontinuousMigrationsHook hooks stepIx
                | otherwise ->
                    lift . lift $ logMismatchHook hooks stepIx actStepNm stepNm
@@ -168,7 +168,7 @@ bringUpToDateWithHooks hooks be@(BeamMigrationBackend { backendRenderSyntax = re
                      step
 
                  runInsert $ insert (_beamMigrateLogEntries (beamMigrateDb @be @m)) $
-                   insertExpressions [ LogEntry (val_ stepIx) (val_ stepName) currentTimestamp_ ]
+                   insertExpressions [ LogEntry (val_ $ fromIntegral stepIx) (val_ stepName) currentTimestamp_ ]
                  endStepHook hooks stepIx stepName
 
                  return ret)

--- a/beam-postgres/Database/Beam/Postgres/Syntax.hs
+++ b/beam-postgres/Database/Beam/Postgres/Syntax.hs
@@ -11,6 +11,7 @@
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE CPP #-}
+{-# LANGUAGE UndecidableInstances #-}
 
 -- | Data types for Postgres syntax. Access is given mainly for extension
 -- modules. The types and definitions here are likely to change.
@@ -86,6 +87,7 @@ module Database.Beam.Postgres.Syntax
     , PostgresInaccessible ) where
 
 import           Database.Beam hiding (insert)
+import           Database.Beam.Backend.Internal.Compat
 import           Database.Beam.Backend.SQL
 import           Database.Beam.Migrate
 import           Database.Beam.Migrate.Checks (HasDataTypeCreatedCheck(..))
@@ -122,6 +124,7 @@ import           Data.Time (LocalTime, UTCTime, TimeOfDay, NominalDiffTime, Day)
 import           Data.UUID.Types (UUID)
 import           Data.Word
 import qualified Data.Vector as V
+import           GHC.TypeLits
 
 import qualified Database.PostgreSQL.Simple.ToField as Pg
 import qualified Database.PostgreSQL.Simple.TypeInfo.Static as Pg
@@ -1177,13 +1180,11 @@ instance DatabasePredicate PgHasEnum where
 DEFAULT_SQL_SYNTAX(Bool)
 DEFAULT_SQL_SYNTAX(Double)
 DEFAULT_SQL_SYNTAX(Float)
-DEFAULT_SQL_SYNTAX(Int)
 DEFAULT_SQL_SYNTAX(Int8)
 DEFAULT_SQL_SYNTAX(Int16)
 DEFAULT_SQL_SYNTAX(Int32)
 DEFAULT_SQL_SYNTAX(Int64)
 DEFAULT_SQL_SYNTAX(Integer)
-DEFAULT_SQL_SYNTAX(Word)
 DEFAULT_SQL_SYNTAX(Word8)
 DEFAULT_SQL_SYNTAX(Word16)
 DEFAULT_SQL_SYNTAX(Word32)
@@ -1226,6 +1227,12 @@ instance HasSqlValueSyntax PgValueSyntax BL.ByteString where
   sqlValueSyntax = defaultPgValueSyntax . Pg.Binary
 
 instance Pg.ToField a => HasSqlValueSyntax PgValueSyntax (V.Vector a) where
+  sqlValueSyntax = defaultPgValueSyntax
+
+instance TypeError (PreferExplicitSize Int Int32) => HasSqlValueSyntax PgValueSyntax Int where
+  sqlValueSyntax = defaultPgValueSyntax
+
+instance TypeError (PreferExplicitSize Word Word32) => HasSqlValueSyntax PgValueSyntax Word where
   sqlValueSyntax = defaultPgValueSyntax
 
 pgQuotedIdentifier :: T.Text -> PgSyntax

--- a/beam-postgres/Database/Beam/Postgres/Types.hs
+++ b/beam-postgres/Database/Beam/Postgres/Types.hs
@@ -1,6 +1,5 @@
 {-# OPTIONS_GHC -fno-warn-orphans #-}
 
-{-# LANGUAGE CPP #-}
 {-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE UndecidableInstances #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
@@ -16,10 +15,9 @@ module Database.Beam.Postgres.Types
   , fromPgScientificOrIntegral
   ) where
 
-#include "MachDeps.h"
-
 import           Database.Beam
 import           Database.Beam.Backend
+import           Database.Beam.Backend.Internal.Compat
 import           Database.Beam.Migrate.Generics
 import           Database.Beam.Migrate.SQL (BeamMigrateOnlySqlBackend)
 import           Database.Beam.Postgres.Syntax
@@ -46,6 +44,7 @@ import           Data.Time (UTCTime, Day, TimeOfDay, LocalTime, NominalDiffTime,
 import           Data.UUID.Types (UUID)
 import           Data.Vector (Vector)
 import           Data.Word
+import           GHC.TypeLits
 
 -- | The Postgres backend type, used to parameterize 'MonadBeam'. See the
 -- definitions there for more information. The corresponding query monad is
@@ -97,24 +96,28 @@ instance FromBackendRow Postgres SqlNull
 instance FromBackendRow Postgres Bool
 instance FromBackendRow Postgres Char
 instance FromBackendRow Postgres Double
-instance FromBackendRow Postgres Int where
-  fromBackendRow = fromPgIntegral
 instance FromBackendRow Postgres Int16 where
   fromBackendRow = fromPgIntegral
 instance FromBackendRow Postgres Int32 where
   fromBackendRow = fromPgIntegral
 instance FromBackendRow Postgres Int64 where
   fromBackendRow = fromPgIntegral
+
+instance TypeError (PreferExplicitSize Int Int32) => FromBackendRow Postgres Int where
+  fromBackendRow = fromPgIntegral
+
 -- Word values are serialized as SQL @NUMBER@ types to guarantee full domain coverage.
 -- However, we want them te be serialized/deserialized as whichever type makes sense
-instance FromBackendRow Postgres Word where
-  fromBackendRow = fromPgScientificOrIntegral
 instance FromBackendRow Postgres Word16 where
   fromBackendRow = fromPgScientificOrIntegral
 instance FromBackendRow Postgres Word32 where
   fromBackendRow = fromPgScientificOrIntegral
 instance FromBackendRow Postgres Word64 where
   fromBackendRow = fromPgScientificOrIntegral
+
+instance TypeError (PreferExplicitSize Word Word32) => FromBackendRow Postgres Word where
+  fromBackendRow = fromPgScientificOrIntegral
+
 instance FromBackendRow Postgres Integer
 instance FromBackendRow Postgres ByteString
 instance FromBackendRow Postgres Scientific
@@ -185,16 +188,6 @@ instance HasDefaultSqlDataType Postgres LocalTime where
 instance HasDefaultSqlDataType Postgres UTCTime where
   defaultSqlDataType _ _ _ = timestampType Nothing True
 
-#if WORD_SIZE_IN_BITS == 32
-instance HasDefaultSqlDataType Postgres (SqlSerial Int) where
-  defaultSqlDataType _ = defaultSqlDataType (Proxy @(SqlSerial Int32))
-#elif WORD_SIZE_IN_BITS == 64
-instance HasDefaultSqlDataType Postgres (SqlSerial Int) where
-  defaultSqlDataType _ = defaultSqlDataType (Proxy @(SqlSerial Int64))
-#else
-#error "Unsupported word size; check the value of WORD_SIZE_IN_BITS"
-#endif
-
 instance HasDefaultSqlDataType Postgres (SqlSerial Int16) where
   defaultSqlDataType _ _ False = pgSmallSerialType
   defaultSqlDataType _ _ _ = smallIntType
@@ -206,6 +199,9 @@ instance HasDefaultSqlDataType Postgres (SqlSerial Int32) where
 instance HasDefaultSqlDataType Postgres (SqlSerial Int64) where
   defaultSqlDataType _ _ False = pgBigSerialType
   defaultSqlDataType _ _ _ = bigIntType
+
+instance TypeError (PreferExplicitSize Int Int32) => HasDefaultSqlDataType Postgres (SqlSerial Int) where
+  defaultSqlDataType _ = defaultSqlDataType (Proxy @(SqlSerial Int32))
 
 instance HasDefaultSqlDataType Postgres UUID where
   defaultSqlDataType _ _ _ = pgUuidType
@@ -219,13 +215,11 @@ instance HasDefaultSqlDataType Postgres UUID where
 PG_HAS_EQUALITY_CHECK(Bool)
 PG_HAS_EQUALITY_CHECK(Double)
 PG_HAS_EQUALITY_CHECK(Float)
-PG_HAS_EQUALITY_CHECK(Int)
 PG_HAS_EQUALITY_CHECK(Int8)
 PG_HAS_EQUALITY_CHECK(Int16)
 PG_HAS_EQUALITY_CHECK(Int32)
 PG_HAS_EQUALITY_CHECK(Int64)
 PG_HAS_EQUALITY_CHECK(Integer)
-PG_HAS_EQUALITY_CHECK(Word)
 PG_HAS_EQUALITY_CHECK(Word8)
 PG_HAS_EQUALITY_CHECK(Word16)
 PG_HAS_EQUALITY_CHECK(Word32)
@@ -254,6 +248,11 @@ PG_HAS_EQUALITY_CHECK(BL.ByteString)
 PG_HAS_EQUALITY_CHECK(Vector a)
 PG_HAS_EQUALITY_CHECK(CI Text)
 PG_HAS_EQUALITY_CHECK(CI TL.Text)
+
+instance TypeError (PreferExplicitSize Int Int32) => HasSqlEqualityCheck Postgres Int
+instance TypeError (PreferExplicitSize Int Int32) => HasSqlQuantifiedEqualityCheck Postgres Int
+instance TypeError (PreferExplicitSize Word Word32) => HasSqlEqualityCheck Postgres Word
+instance TypeError (PreferExplicitSize Word Word32) => HasSqlQuantifiedEqualityCheck Postgres Word
 
 instance HasSqlEqualityCheck Postgres a =>
   HasSqlEqualityCheck Postgres (Tagged t a)

--- a/beam-postgres/examples/Pagila/Schema/CustomMigrateExample.hs
+++ b/beam-postgres/examples/Pagila/Schema/CustomMigrateExample.hs
@@ -19,6 +19,7 @@ import           Database.Beam.Backend.SQL
 import           Database.Beam.Migrate.SQL.Types (TableFieldSchema(..), DataType(..))
 import           Database.Beam.Backend.SQL.Types (SqlSerial)
 
+import           Data.Int
 import qualified Data.Text as T
 import           Data.Time.LocalTime (LocalTime)
 import           Database.PostgreSQL.Simple.FromField
@@ -60,7 +61,7 @@ shippingCarrierType = DataType pgTextType
 -- | Address table
 data AddressT f
   = AddressT
-  { addressId         :: Columnar f (SqlSerial Int)
+  { addressId         :: Columnar f (SqlSerial Int32)
   , addressAddress1   :: Columnar f T.Text
   , addressAddress2   :: Columnar f (Maybe T.Text)
   , addressDistrict   :: Columnar f T.Text
@@ -74,7 +75,7 @@ deriving instance Show Address
 deriving instance Eq Address
 
 instance Table AddressT where
-  data PrimaryKey AddressT f = AddressId (Columnar f (SqlSerial Int)) deriving Generic
+  data PrimaryKey AddressT f = AddressId (Columnar f (SqlSerial Int32)) deriving Generic
   primaryKey = AddressId . addressId
 type AddressId = PrimaryKey AddressT Identity
 deriving instance Show AddressId

--- a/beam-postgres/examples/Pagila/Schema/V0001.hs
+++ b/beam-postgres/examples/Pagila/Schema/V0001.hs
@@ -28,7 +28,7 @@ import Data.Scientific (Scientific)
 
 data AddressT f
   = AddressT
-  { addressId         :: Columnar f (SqlSerial Int)
+  { addressId         :: Columnar f (SqlSerial Int32)
   , addressAddress1   :: Columnar f Text
   , addressAddress2   :: Columnar f (Maybe Text)
   , addressDistrict   :: Columnar f Text
@@ -42,7 +42,7 @@ deriving instance Show Address
 deriving instance Eq Address
 
 instance Table AddressT where
-  data PrimaryKey AddressT f = AddressId (Columnar f (SqlSerial Int)) deriving Generic
+  data PrimaryKey AddressT f = AddressId (Columnar f (SqlSerial Int32)) deriving Generic
   primaryKey = AddressId . addressId
 type AddressId = PrimaryKey AddressT Identity
 deriving instance Show AddressId
@@ -52,7 +52,7 @@ deriving instance Eq AddressId
 
 data CityT f
   = CityT
-  { cityId         :: Columnar f Int
+  { cityId         :: Columnar f Int32
   , cityName       :: Columnar f Text
   , cityCountryId  :: PrimaryKey CountryT f
   , cityLastUpdate :: Columnar f LocalTime
@@ -62,7 +62,7 @@ deriving instance Show City
 deriving instance Eq City
 
 instance Table CityT where
-  data PrimaryKey CityT f = CityId (Columnar f Int) deriving Generic
+  data PrimaryKey CityT f = CityId (Columnar f Int32) deriving Generic
   primaryKey = CityId . cityId
 type CityId = PrimaryKey CityT Identity
 deriving instance Show CityId
@@ -72,7 +72,7 @@ deriving instance Eq CityId
 
 data CountryT f
   = CountryT
-  { countryId          :: Columnar f Int
+  { countryId          :: Columnar f Int32
   , countryName        :: Columnar f Text
   , countryLastUpdated :: Columnar f LocalTime
   } deriving Generic
@@ -81,7 +81,7 @@ deriving instance Show Country
 deriving instance Eq Country
 
 instance Table CountryT where
-  data PrimaryKey CountryT f = CountryId (Columnar f Int) deriving Generic
+  data PrimaryKey CountryT f = CountryId (Columnar f Int32) deriving Generic
   primaryKey = CountryId . countryId
 type CountryId = PrimaryKey CountryT Identity
 deriving instance Show CountryId
@@ -91,7 +91,7 @@ deriving instance Eq CountryId
 
 data ActorT f
   = ActorT
-  { actorId :: Columnar f (SqlSerial Int)
+  { actorId :: Columnar f (SqlSerial Int32)
   , actorFirstName :: Columnar f Text
   , actorLastName :: Columnar f Text
   , actorLastUpdate :: Columnar f LocalTime
@@ -100,7 +100,7 @@ type Actor = ActorT Identity
 deriving instance Show Actor; deriving instance Eq Actor
 
 instance Table ActorT where
-  data PrimaryKey ActorT f = ActorId (Columnar f (SqlSerial Int))
+  data PrimaryKey ActorT f = ActorId (Columnar f (SqlSerial Int23))
                              deriving Generic
   primaryKey = ActorId . actorId
 type ActorId = PrimaryKey ActorT Identity
@@ -110,7 +110,7 @@ deriving instance Show ActorId; deriving instance Eq ActorId
 
 data CategoryT f
   = CategoryT
-  { categoryId :: Columnar f Int
+  { categoryId :: Columnar f Int32
   , categoryName :: Columnar f Text
   , categoryLastUpdate :: Columnar f LocalTime
   } deriving Generic
@@ -118,7 +118,7 @@ type Category = CategoryT Identity
 deriving instance Show Category; deriving instance Eq Category
 
 instance Table CategoryT where
-  data PrimaryKey CategoryT f = CategoryId (Columnar f Int) deriving Generic
+  data PrimaryKey CategoryT f = CategoryId (Columnar f Int32) deriving Generic
   primaryKey = CategoryId . categoryId
 type CategoryId = PrimaryKey CategoryT Identity
 deriving instance Show CategoryId; deriving instance Eq CategoryId
@@ -127,7 +127,7 @@ deriving instance Show CategoryId; deriving instance Eq CategoryId
 
 data CustomerT f
   = CustomerT
-  { customerId        :: Columnar f (SqlSerial Int)
+  { customerId        :: Columnar f (SqlSerial Int32)
   , customerStore     :: PrimaryKey StoreT f
   , customerFirstName :: Columnar f Text
   , customerLastName  :: Columnar f Text
@@ -141,7 +141,7 @@ type Customer = CustomerT Identity
 deriving instance Show Customer; deriving instance Eq Customer
 
 instance Table CustomerT where
-  data PrimaryKey CustomerT f = CustomerId (Columnar f (SqlSerial Int))
+  data PrimaryKey CustomerT f = CustomerId (Columnar f (SqlSerial Int32))
                                 deriving Generic
   primaryKey = CustomerId . customerId
 type CustomerId = PrimaryKey CustomerT Identity
@@ -151,7 +151,7 @@ deriving instance Show CustomerId; deriving instance Eq CustomerId
 
 data StoreT f
   = StoreT
-  { storeId      :: Columnar f Int
+  { storeId      :: Columnar f Int32
   , storeManager :: PrimaryKey StaffT f
   , storeAddress :: PrimaryKey AddressT f
   , lastUpdate   :: Columnar f LocalTime
@@ -160,7 +160,7 @@ type Store = StoreT Identity
 deriving instance Show Store; deriving instance Eq Store
 
 instance Table StoreT where
-  data PrimaryKey StoreT f = StoreId (Columnar f Int) deriving Generic
+  data PrimaryKey StoreT f = StoreId (Columnar f Int32) deriving Generic
   primaryKey = StoreId . storeId
 type StoreId = PrimaryKey StoreT Identity
 deriving instance Show StoreId; deriving instance Eq StoreId
@@ -169,7 +169,7 @@ deriving instance Show StoreId; deriving instance Eq StoreId
 
 data StaffT f
   = StaffT
-  { staffId        :: Columnar f Int
+  { staffId        :: Columnar f Int32
   , staffFirstName :: Columnar f Text
   , staffLastName  :: Columnar f Text
   , staffAddress   :: PrimaryKey AddressT f
@@ -185,7 +185,7 @@ type Staff = StaffT Identity
 deriving instance Eq Staff; deriving instance Show Staff
 
 instance Table StaffT where
-  data PrimaryKey StaffT f = StaffId (Columnar f Int) deriving Generic
+  data PrimaryKey StaffT f = StaffId (Columnar f Int32) deriving Generic
   primaryKey = StaffId . staffId
 type StaffId = PrimaryKey StaffT Identity
 deriving instance Eq StaffId; deriving instance Show StaffId
@@ -194,15 +194,15 @@ deriving instance Eq StaffId; deriving instance Show StaffId
 
 data FilmT f
   = FilmT
-  { filmId             :: Columnar f (SqlSerial Int)
+  { filmId             :: Columnar f (SqlSerial Int32)
   , filmTitle          :: Columnar f Text
   , filmDescription    :: Columnar f Text
-  , filmReleaseYear    :: Columnar f Int
+  , filmReleaseYear    :: Columnar f Int32
   , filmLanguage       :: PrimaryKey LanguageT f
   , filmOriginalLanguage :: PrimaryKey LanguageT f
-  , filmRentalDuration :: Columnar f Int
+  , filmRentalDuration :: Columnar f Int32
   , filmRentalRate     :: Columnar f Scientific
-  , filmLength         :: Columnar f Int
+  , filmLength         :: Columnar f Int32
   , filmReplacementCost :: Columnar f Scientific
   , filmRating         :: Columnar f Text
   , filmLastUpdate     :: Columnar f LocalTime
@@ -211,7 +211,7 @@ type Film = FilmT Identity
 deriving instance Eq Film; deriving instance Show Film
 
 instance Table FilmT where
-  data PrimaryKey FilmT f = FilmId (Columnar f (SqlSerial Int))
+  data PrimaryKey FilmT f = FilmId (Columnar f (SqlSerial Int32))
                             deriving Generic
   primaryKey = FilmId . filmId
 type FilmId = PrimaryKey FilmT Identity
@@ -239,7 +239,7 @@ deriving instance Eq FilmCategoryId; deriving instance Show FilmCategoryId
 
 data LanguageT f
   = LanguageT
-  { languageId   :: Columnar f (SqlSerial Int)
+  { languageId   :: Columnar f (SqlSerial Int32)
   , languageName :: Columnar f Text
   , languageLastUpdate :: Columnar f LocalTime
   }  deriving Generic
@@ -247,7 +247,7 @@ type Language = LanguageT Identity
 deriving instance Eq Language; deriving instance Show Language
 
 instance Table LanguageT where
-  data PrimaryKey LanguageT f = LanguageId (Columnar f (SqlSerial Int))
+  data PrimaryKey LanguageT f = LanguageId (Columnar f (SqlSerial Int32))
                                 deriving Generic
   primaryKey = LanguageId . languageId
 type LanguageId = PrimaryKey LanguageT Identity

--- a/beam-postgres/examples/Pagila/Test.hs
+++ b/beam-postgres/examples/Pagila/Test.hs
@@ -3,6 +3,7 @@ module Pagila.Test where
 
 import Control.Arrow
 
+import Data.Int
 import Data.Proxy
 import Data.Text(Text)
 
@@ -20,13 +21,13 @@ import Database.Beam.Migrate.SQL.Types
 
 data SimpleTbl f
   = SimpleTbl
-  { simpletblField1 :: Columnar f Int
+  { simpletblField1 :: Columnar f Int32
   , simpletblField2 :: Columnar f (Maybe Text) }
   deriving Generic
 instance Beamable SimpleTbl
 
 instance Table SimpleTbl where
-  data PrimaryKey SimpleTbl f = SimpleTblId (Columnar f Int) deriving Generic
+  data PrimaryKey SimpleTbl f = SimpleTblId (Columnar f Int32) deriving Generic
   primaryKey = SimpleTblId <$> simpletblField1
 instance Beamable (PrimaryKey SimpleTbl)
 

--- a/beam-postgres/test/Database/Beam/Postgres/Test/DataTypes.hs
+++ b/beam-postgres/test/Database/Beam/Postgres/Test/DataTypes.hs
@@ -11,6 +11,7 @@ import Database.Beam.Backend.SQL.BeamExtensions
 import Control.Exception (SomeException(..), handle)
 
 import Data.ByteString (ByteString)
+import Data.Int
 import Data.Text (Text)
 
 import Test.Tasty
@@ -24,12 +25,12 @@ tests postgresConn =
 
 data JsonT f
     = JsonT
-    { _key :: C f Int
+    { _key :: C f Int32
     , _field1 :: C f (PgJSON String) }
     deriving (Generic, Beamable)
 
 instance Table JsonT where
-    data PrimaryKey JsonT f = JsonKey (C f Int)
+    data PrimaryKey JsonT f = JsonKey (C f Int32)
       deriving (Generic, Beamable)
     primaryKey = JsonKey <$> _key
 
@@ -80,23 +81,23 @@ jsonNulTest pgConn =
       return ()
 
 data TblT f
-    = Tbl { _tblKey :: C f Int, _tblValue :: C f Text }
+    = Tbl { _tblKey :: C f Int32, _tblValue :: C f Text }
       deriving (Generic, Beamable)
 
 deriving instance Show (TblT Identity)
 deriving instance Eq (TblT Identity)
 
 instance Table TblT where
-    data PrimaryKey TblT f = TblKey (C f Int)
+    data PrimaryKey TblT f = TblKey (C f Int32)
       deriving (Generic, Beamable)
     primaryKey = TblKey <$> _tblKey
 
 data WrongTblT f
-    = WrongTbl { _wrongTblKey :: C f Int, _wrongTblValue :: C f Int }
+    = WrongTbl { _wrongTblKey :: C f Int32, _wrongTblValue :: C f Int32 }
       deriving (Generic, Beamable)
 
 instance Table WrongTblT where
-    data PrimaryKey WrongTblT f = WrongTblKey (C f Int)
+    data PrimaryKey WrongTblT f = WrongTblKey (C f Int32)
       deriving (Generic, Beamable)
     primaryKey = WrongTblKey <$> _wrongTblKey
 

--- a/beam-postgres/test/Database/Beam/Postgres/Test/Marshal.hs
+++ b/beam-postgres/test/Database/Beam/Postgres/Test/Marshal.hs
@@ -104,13 +104,13 @@ tests postgresConn =
 
 data MarshalTable a f
     = MarshalTable
-    { _marshalTableId    :: C f (SqlSerial Int)
+    { _marshalTableId    :: C f (SqlSerial Int32)
     , _marshalTableEntry :: C f a
     } deriving (Generic)
 instance Beamable (MarshalTable a)
 
 instance Typeable a => Table (MarshalTable a) where
-    data PrimaryKey (MarshalTable a) f = MarshalTableKey (C f (SqlSerial Int))
+    data PrimaryKey (MarshalTable a) f = MarshalTableKey (C f (SqlSerial Int32))
       deriving (Generic, Beamable)
     primaryKey = MarshalTableKey . _marshalTableId
 

--- a/beam-sqlite/Database/Beam/Sqlite/Syntax.hs
+++ b/beam-sqlite/Database/Beam/Sqlite/Syntax.hs
@@ -43,6 +43,7 @@ module Database.Beam.Sqlite.Syntax
   , sqliteRenderSyntaxScript
   ) where
 
+import           Database.Beam.Backend.Internal.Compat
 import           Database.Beam.Backend.SQL
 import           Database.Beam.Backend.SQL.AST (ExtractField(..))
 import           Database.Beam.Haskell.Syntax
@@ -71,6 +72,7 @@ import           Data.Word
 #if !MIN_VERSION_base(4, 11, 0)
 import           Data.Semigroup
 #endif
+import           GHC.TypeLits
 
 import           Database.SQLite.Simple (SQLData(..))
 
@@ -688,8 +690,6 @@ instance IsSql92OrderingSyntax SqliteOrderingSyntax where
   ascOrdering e = SqliteOrderingSyntax (fromSqliteExpression e <> emit " ASC")
   descOrdering e = SqliteOrderingSyntax (fromSqliteExpression e <> emit " DESC")
 
-instance HasSqlValueSyntax SqliteValueSyntax Int where
-  sqlValueSyntax i = SqliteValueSyntax (emitValue (SQLInteger (fromIntegral i)))
 instance HasSqlValueSyntax SqliteValueSyntax Int8 where
   sqlValueSyntax i = SqliteValueSyntax (emitValue (SQLInteger (fromIntegral i)))
 instance HasSqlValueSyntax SqliteValueSyntax Int16 where
@@ -697,8 +697,6 @@ instance HasSqlValueSyntax SqliteValueSyntax Int16 where
 instance HasSqlValueSyntax SqliteValueSyntax Int32 where
   sqlValueSyntax i = SqliteValueSyntax (emitValue (SQLInteger (fromIntegral i)))
 instance HasSqlValueSyntax SqliteValueSyntax Int64 where
-  sqlValueSyntax i = SqliteValueSyntax (emitValue (SQLInteger (fromIntegral i)))
-instance HasSqlValueSyntax SqliteValueSyntax Word where
   sqlValueSyntax i = SqliteValueSyntax (emitValue (SQLInteger (fromIntegral i)))
 instance HasSqlValueSyntax SqliteValueSyntax Word8 where
   sqlValueSyntax i = SqliteValueSyntax (emitValue (SQLInteger (fromIntegral i)))
@@ -715,7 +713,7 @@ instance HasSqlValueSyntax SqliteValueSyntax Float where
 instance HasSqlValueSyntax SqliteValueSyntax Double where
   sqlValueSyntax f = SqliteValueSyntax (emitValue (SQLFloat f))
 instance HasSqlValueSyntax SqliteValueSyntax Bool where
-  sqlValueSyntax = sqlValueSyntax . (\b -> if b then 1 else 0 :: Int)
+  sqlValueSyntax = sqlValueSyntax . (\b -> if b then 1 else 0 :: Int32)
 instance HasSqlValueSyntax SqliteValueSyntax SqlNull where
   sqlValueSyntax _ = SqliteValueSyntax (emit "NULL")
 instance HasSqlValueSyntax SqliteValueSyntax String where
@@ -728,6 +726,12 @@ instance HasSqlValueSyntax SqliteValueSyntax x =>
   HasSqlValueSyntax SqliteValueSyntax (Maybe x) where
   sqlValueSyntax (Just x) = sqlValueSyntax x
   sqlValueSyntax Nothing = sqlValueSyntax SqlNull
+
+instance TypeError (PreferExplicitSize Int Int32) => HasSqlValueSyntax SqliteValueSyntax Int where
+  sqlValueSyntax i = SqliteValueSyntax (emitValue (SQLInteger (fromIntegral i)))
+
+instance TypeError (PreferExplicitSize Word Word32) => HasSqlValueSyntax SqliteValueSyntax Word where
+  sqlValueSyntax i = SqliteValueSyntax (emitValue (SQLInteger (fromIntegral i)))
 
 instance IsCustomSqlSyntax SqliteExpressionSyntax where
   newtype CustomSqlSyntax SqliteExpressionSyntax =


### PR DESCRIPTION
Fixes #496. It's possible I missed some, but all instances for `Int` and `Word` should now be replaced with a helpful custom type error.