### PR TITLE
Fix SQLite IN with row values and add tests

### DIFF
--- a/beam-core/Database/Beam/Query.hs
+++ b/beam-core/Database/Beam/Query.hs
@@ -42,7 +42,7 @@ module Database.Beam.Query
     -- ** Unquantified comparison operators
     , HasSqlEqualityCheck(..), HasSqlQuantifiedEqualityCheck(..)
     , SqlEq(..), SqlOrd(..), SqlIn(..)
-    , HasSqlInTable
+    , HasSqlInTable(..)
 
     -- ** Quantified Comparison Operators #quantified-comparison-operator#
     , SqlEqQuantified(..), SqlOrdQuantified(..)

--- a/beam-sqlite/Database/Beam/Sqlite/Connection.hs
+++ b/beam-sqlite/Database/Beam/Sqlite/Connection.hs
@@ -28,7 +28,7 @@ import           Database.Beam.Query ( QExpr, QField
                                      , HasQBuilder(..), HasSqlEqualityCheck
                                      , HasSqlQuantifiedEqualityCheck
                                      , DataType(..)
-                                     , HasSqlInTable
+                                     , HasSqlInTable(..)
                                      , insert, current_ )
 import           Database.Beam.Query.Internal
 import           Database.Beam.Query.SQL92
@@ -108,6 +108,11 @@ instance HasQBuilder Sqlite where
   buildSqlQuery = buildSql92Query' False -- SQLite does not support arbitrarily nesting UNION, INTERSECT, and EXCEPT
 
 instance HasSqlInTable Sqlite where
+  inRowValuesE Proxy e es = SqliteExpressionSyntax $ mconcat
+    [ parens $ fromSqliteExpression e
+    , emit " IN "
+    , parens $ emit "VALUES " <> commas (map fromSqliteExpression es)
+    ]
 
 instance BeamSqlBackendIsString Sqlite T.Text
 instance BeamSqlBackendIsString Sqlite String

--- a/beam-sqlite/test/Database/Beam/Sqlite/Test.hs
+++ b/beam-sqlite/test/Database/Beam/Sqlite/Test.hs
@@ -2,6 +2,8 @@ module Database.Beam.Sqlite.Test where
 
 import Control.Exception
 import Database.SQLite.Simple
+import Test.Tasty.HUnit
 
 withTestDb :: (Connection -> IO a) -> IO a
-withTestDb = bracket (open ":memory:") close
+withTestDb = flip catch asFailure . bracket (open ":memory:") close
+  where asFailure (e :: SomeException) = assertFailure $ show e

--- a/beam-sqlite/test/Database/Beam/Sqlite/Test/Select.hs
+++ b/beam-sqlite/test/Database/Beam/Sqlite/Test/Select.hs
@@ -13,13 +13,27 @@ import Database.Beam.Sqlite.Test
 tests :: TestTree
 tests = testGroup "Selection tests"
   [ expectFail testExceptValues
+  , testInRowValues
   ]
+
+data Pair f = Pair
+  { _left :: C f Bool
+  , _right :: C f Bool
+  } deriving (Generic, Beamable)
+
+testInRowValues :: TestTree
+testInRowValues = testCase "IN with row values works" $
+  withTestDb $ \conn -> do
+    result <- runBeamSqlite conn $ runSelectReturningList $ select $ do
+      let p :: forall ctx s. Pair (QGenExpr ctx Sqlite s)
+          p = val_ $ Pair False False
+      return $ p `in_` [p, p]
+    assertEqual "result" [True] result
 
 -- | Regression test for <https://github.com/haskell-beam/beam/issues/326 #326>
 testExceptValues :: TestTree
 testExceptValues = testCase "EXCEPT with VALUES works" $
-  flip catch asFailure $ withTestDb $ \conn -> do
+  withTestDb $ \conn -> do
     result <- runBeamSqlite conn $ runSelectReturningList $ select $
       values_ [as_ @Bool $ val_ True, val_ False] `except_` values_ [val_ False]
     assertEqual "result" [True] result
-  where asFailure (e :: SomeException) = assertFailure $ show e


### PR DESCRIPTION
I think when I wrote #384 I tried it manually with one multi-column row value, or multiple single-column rows, both of which SQLite just happens to support with the expected syntax. With multiple multi-column rows however, it's required to turn the list into a sub-query with `VALUES`.