### PR TITLE
Fix beam-sqlite runInsertReturningList

### DIFF
--- a/beam-sqlite/ChangeLog.md
+++ b/beam-sqlite/ChangeLog.md
@@ -1,3 +1,7 @@
+# 0.5.0.0
+
+Fix `runInsertReturningList` for when the database column order and beam column order disagree.
+
 # 0.3.2.0
 
 Add `Semigroup` instances to prepare for GHC 8.4 and Stackage nightly

--- a/beam-sqlite/Database/Beam/Sqlite/Syntax.hs
+++ b/beam-sqlite/Database/Beam/Sqlite/Syntax.hs
@@ -37,7 +37,7 @@ module Database.Beam.Sqlite.Syntax
     -- * Building and consuming 'SqliteSyntax'
   , fromSqliteCommand, formatSqliteInsert, formatSqliteInsertOnConflict
 
-  , emit, emitValue, parens, commas
+  , emit, emitValue, parens, commas, quotedIdentifier
 
   , sqliteEscape, withPlaceholders
   , sqliteRenderSyntaxScript

--- a/beam-sqlite/beam-sqlite.cabal
+++ b/beam-sqlite/beam-sqlite.cabal
@@ -67,7 +67,9 @@ test-suite beam-sqlite-tests
     sqlite-simple,
     tasty,
     tasty-expected-failure,
-    tasty-hunit
+    tasty-hunit,
+    text,
+    time
   other-modules:
     Database.Beam.Sqlite.Test
     Database.Beam.Sqlite.Test.Migrate
@@ -83,6 +85,7 @@ test-suite beam-sqlite-tests
     OverloadedStrings,
     RankNTypes,
     ScopedTypeVariables,
+    StandaloneDeriving,
     TypeApplications,
     TypeFamilies
 

--- a/beam-sqlite/test/Database/Beam/Sqlite/Test/Select.hs
+++ b/beam-sqlite/test/Database/Beam/Sqlite/Test/Select.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE OverloadedStrings #-}
+
 module Database.Beam.Sqlite.Test.Select (tests) where
 
 import Control.Exception
@@ -5,15 +7,22 @@ import Test.Tasty
 import Test.Tasty.ExpectedFailure
 import Test.Tasty.HUnit
 
+import Data.Int (Int32)
+import Data.Text (Text)
+import Data.Time (LocalTime)
+
 import Database.Beam
 import Database.Beam.Sqlite
 
 import Database.Beam.Sqlite.Test
 
+import Database.SQLite.Simple (execute_)
+
 tests :: TestTree
 tests = testGroup "Selection tests"
   [ expectFail testExceptValues
   , testInRowValues
+  , testInsertReturningColumnOrder -- In select tests because the bug was with the selects
   ]
 
 data Pair f = Pair
@@ -37,3 +46,47 @@ testExceptValues = testCase "EXCEPT with VALUES works" $
     result <- runBeamSqlite conn $ runSelectReturningList $ select $
       values_ [as_ @Bool $ val_ True, val_ False] `except_` values_ [val_ False]
     assertEqual "result" [True] result
+
+data TestTableT f
+  = TestTable
+  { ttId :: C f Int32
+  , ttFirstName :: C f Text
+  , ttLastName  :: C f Text
+  , ttAge       :: C f Int32
+  , ttDateJoined :: C f LocalTime
+  } deriving (Generic, Beamable)
+
+deriving instance Show (TestTableT Identity)
+deriving instance Eq (TestTableT Identity)
+
+instance Table TestTableT where
+  data PrimaryKey TestTableT f = TestTableKey (C f Int32)
+    deriving (Generic, Beamable)
+  primaryKey = TestTableKey <$> ttId
+
+data TestTableDb entity
+  = TestTableDb
+  { dbTestTable :: entity (TableEntity TestTableT)
+  } deriving (Generic, Database Sqlite)
+
+testDatabase :: DatabaseSettings be TestTableDb
+testDatabase = defaultDbSettings
+
+testInsertReturningColumnOrder :: TestTree
+testInsertReturningColumnOrder = testCase "runInsertReturningList with mismatching column order" $ do
+  withTestDb $ \conn -> do
+    execute_ conn "CREATE TABLE test_table ( date_joined TIMESTAMP NOT NULL, first_name TEXT NOT NULL, id INT PRIMARY KEY, age INT NOT NULL, last_name TEXT NOT NULL )"
+    inserted <-
+      runBeamSqlite conn $ runInsertReturningList $
+      insert (dbTestTable testDatabase) $
+      insertExpressions [ TestTable 0 (concat_ [ "j", "im" ]) "smith" 19 currentTimestamp_
+                        , TestTable 1 "sally" "apple" ((val_ 56 + val_ 109) `div_` 5) currentTimestamp_
+                        , TestTable 4 "blah" "blah" (-1) currentTimestamp_ ]
+
+    let dateJoined = ttDateJoined (head inserted)
+
+        expected = [ TestTable 0 "jim" "smith" 19 dateJoined
+                   , TestTable 1 "sally" "apple" 33 dateJoined
+                   , TestTable 4 "blah" "blah" (-1) dateJoined ]
+
+    assertEqual "insert values" inserted expected


### PR DESCRIPTION
runInsertReturningList on Sqlite does a bit of a dance to get the results out. The temporary table has to be created using a `SELECT *` so that type information which `beam-core` does not have available is propagated to the new temporary table. However, this can cause deserialization issues if the fields in SQLite are not in the same order as in Haskell. This is fixed by ensuring we `SELECT` from the temporary table using an explicit projection.