### PR TITLE
Expose IsNotNull typeclass

### DIFF
--- a/beam-migrate/Database/Beam/Migrate/SQL/Tables.hs
+++ b/beam-migrate/Database/Beam/Migrate/SQL/Tables.hs
@@ -29,6 +29,7 @@ module Database.Beam.Migrate.SQL.Tables
     -- ** Internal classes
     --    Provided without documentation for use in type signatures
   , FieldReturnType(..)
+  , IsNotNull(..)
   ) where
 
 import Database.Beam


### PR DESCRIPTION
This is minor, but I needed this in some type signatures. It was because I'm adding extra type parameters to my tables and using type families in them, so the compiler can't always see the real type and infer `IsNotNull`.