### PR TITLE
Copy Postgres result data when reading rows

### DIFF
--- a/beam-postgres/Database/Beam/Postgres/Connection.hs
+++ b/beam-postgres/Database/Beam/Postgres/Connection.hs
@@ -143,7 +143,7 @@ runPgRowReader conn rowIdx res fields (FromBackendRowM readRow) =
     step (ParseOneField _) curCol colCount _
       | curCol >= colCount = pure (Left (BeamRowReadError (Just (fromIntegral curCol)) (ColumnNotEnoughColumns (fromIntegral colCount))))
     step (ParseOneField (next' :: next -> _)) curCol colCount (field:remainingFields) =
-      do fieldValue <- Pg.getvalue res rowIdx (Pg.Col curCol)
+      do fieldValue <- Pg.getvalue' res rowIdx (Pg.Col curCol)
          res' <- Pg.runConversion (Pg.fromField field fieldValue) conn
          case res' of
            Pg.Errors errs ->


### PR DESCRIPTION
Tentative fix for #544.

We currently [manually free](https://github.com/haskell-beam/beam/blob/4d30ed45b16c41be26cb6301e9033c99379bf2d9/beam-postgres/Database/Beam/Postgres/Connection.hs#L232) the Postgres result object, and it seems that at least for `PgJSONB`, but likely also `PgJSON`, `Text, `ByteString`, etc. it's possible a slice of the underlying bytestring can outlive the result and cause a use-after-free bug.

`postgresql-simple` apparently also [copies](http://hackage.haskell.org/package/postgresql-simple-0.6.4/docs/Database-PostgreSQL-Simple-FromField.html#v:fromField) the data instead of letting GC handle the `Result`, which would be the other possible fix.