### PR TITLE
Order log entries when verifying migration status

### DIFF
--- a/beam-migrate/Database/Beam/Migrate/Simple.hs
+++ b/beam-migrate/Database/Beam/Migrate/Simple.hs
@@ -129,7 +129,7 @@ bringUpToDateWithHooks :: forall db be m
 bringUpToDateWithHooks hooks be@(BeamMigrationBackend { backendRenderSyntax = renderSyntax' }) steps = do
   ensureBackendTables be
 
-  entries <- runSelectReturningList $ select $
+  entries <- runSelectReturningList $ select $ orderBy_ (asc_ . _logEntryId) $
              all_ (_beamMigrateLogEntries (beamMigrateDb @be @m))
   let verifyMigration :: Int -> T.Text -> Migration be a -> StateT [LogEntry] (WriterT (Max Int) m) a
       verifyMigration stepIx stepNm step =


### PR DESCRIPTION
If Postgres decides to return migration log entries in an unexpected order, `bringUpToDateWithHooks` will loop forever. I'm not sure _why_ it loops, but the query should have an `order by` anyway.