### PR TITLE
orderBy_: improve error on missing asc_/desc_

### DIFF
--- a/beam-core/Database/Beam/Query/Combinators.hs
+++ b/beam-core/Database/Beam/Query/Combinators.hs
@@ -84,7 +84,7 @@ import Data.Maybe
 import Data.Proxy
 import Data.Time (LocalTime)
 
-import GHC.TypeLits
+import GHC.TypeLits (TypeError, ErrorMessage(Text))
 
 -- | Introduce all entries of a table into the 'Q' monad
 all_ :: ( Database be db, BeamSqlBackend be )
@@ -660,7 +660,7 @@ instance SqlOrderable be (QOrd be s a) where
 
 instance TypeError ('Text "Missing mandatory sorting order. Use either 'asc_' or 'desc_' to specify sorting order.") =>
     SqlOrderable be (QGenExpr ctx be s a) where
-        makeSQLOrdering = error "SqlOrderable QGenExpr unreachable"
+        makeSQLOrdering = error "unreachable SqlOrderable QGenExpr instance"
 
 instance SqlOrderable be a => SqlOrderable be [a] where
     makeSQLOrdering be = concatMap (makeSQLOrdering be)

--- a/beam-core/Database/Beam/Query/Combinators.hs
+++ b/beam-core/Database/Beam/Query/Combinators.hs
@@ -658,7 +658,7 @@ class SqlOrderable be a | a -> be where
 instance SqlOrderable be (QOrd be s a) where
     makeSQLOrdering _ (QOrd x) = [x]
 
-instance TypeError ('Text "Use either 'asc_' or 'desc_' to define sorting order.") =>
+instance TypeError ('Text "Unspecified sorting order" ':<>: 'Text "Use either 'asc_' or 'desc_' to specify sorting order") =>
     SqlOrderable be (QGenExpr ctx be s a) where
         makeSQLOrdering = error "SqlOrderable QGenExpr unreachable"
 

--- a/beam-core/Database/Beam/Query/Combinators.hs
+++ b/beam-core/Database/Beam/Query/Combinators.hs
@@ -657,11 +657,9 @@ class SqlOrderable be a | a -> be where
     makeSQLOrdering :: Proxy be -> a -> [ WithExprContext (BeamSqlBackendOrderingSyntax be) ]
 instance SqlOrderable be (QOrd be s a) where
     makeSQLOrdering _ (QOrd x) = [x]
-
 instance TypeError ('Text "Missing mandatory sorting order. Use either 'asc_' or 'desc_' to specify sorting order.") =>
     SqlOrderable be (QGenExpr ctx be s a) where
         makeSQLOrdering = error "unreachable SqlOrderable QGenExpr instance"
-
 instance SqlOrderable be a => SqlOrderable be [a] where
     makeSQLOrdering be = concatMap (makeSQLOrdering be)
 instance ( SqlOrderable be a, SqlOrderable be b ) => SqlOrderable be (a, b) where

--- a/beam-core/Database/Beam/Query/Combinators.hs
+++ b/beam-core/Database/Beam/Query/Combinators.hs
@@ -658,7 +658,7 @@ class SqlOrderable be a | a -> be where
 instance SqlOrderable be (QOrd be s a) where
     makeSQLOrdering _ (QOrd x) = [x]
 
-instance TypeError ('Text "Unspecified sorting order" ':<>: 'Text "Use either 'asc_' or 'desc_' to specify sorting order") =>
+instance TypeError ('Text "Missing mandatory sorting order. Use either 'asc_' or 'desc_' to specify sorting order.") =>
     SqlOrderable be (QGenExpr ctx be s a) where
         makeSQLOrdering = error "SqlOrderable QGenExpr unreachable"
 

--- a/beam-core/Database/Beam/Query/Combinators.hs
+++ b/beam-core/Database/Beam/Query/Combinators.hs
@@ -84,6 +84,8 @@ import Data.Maybe
 import Data.Proxy
 import Data.Time (LocalTime)
 
+import GHC.TypeLits
+
 -- | Introduce all entries of a table into the 'Q' monad
 all_ :: ( Database be db, BeamSqlBackend be )
        => DatabaseEntity be db (TableEntity table)
@@ -655,6 +657,11 @@ class SqlOrderable be a | a -> be where
     makeSQLOrdering :: Proxy be -> a -> [ WithExprContext (BeamSqlBackendOrderingSyntax be) ]
 instance SqlOrderable be (QOrd be s a) where
     makeSQLOrdering _ (QOrd x) = [x]
+
+instance TypeError ('Text "Use either 'asc_' or 'desc_' to define sorting order.") =>
+    SqlOrderable be (QGenExpr ctx be s a) where
+        makeSQLOrdering = error "SqlOrderable QGenExpr unreachable"
+
 instance SqlOrderable be a => SqlOrderable be [a] where
     makeSQLOrdering be = concatMap (makeSQLOrdering be)
 instance ( SqlOrderable be a, SqlOrderable be b ) => SqlOrderable be (a, b) where


### PR DESCRIPTION
As we all know, specifying the ordering (`ASC`/`DESC`) in an SQL `ORDER BY` clause is optional. Consequently, when using beam's `orderBy_`, it's natural to incorrectly let the function passed as the first argument return just the field that we wish to order by (in ascending order). When mistakenly doing this, the user is met with the following error message from GHC:

```
    • No instance for (SqlOrderable
                         Pg.Postgres
                         (QGenExpr
                            QValueContext Pg.Postgres (QNested QBaseScope) Path.UTCTime))
        arising from a use of ‘orderBy_’
```

Even though I've used beam for quite a while, I still occasionally do this. A more telling error message would be very helpful in leading me in the right direction. At first glance, it looks like the problem relates to a specific data type not having a well-defined ordering (`No instance for SqlOrderable ...`).  
This can be achieved using GHC's `GHC.TypeLits.TypeError`. By adding a special instance of `SqlOrderable` for `QGenExpr ctx be s a`, we can provide a more helpful error message to the user, which tells them that the problem is that they've left out the ordering.

Side note: I'm mostly concerned with displaying an alternative error message to users (instead of `No instance for SqlOrderable ...`), so feel free to modify the actual error message to your liking.
