### PR TITLE
like_, similarTo_ and ilike_ support different types for haystack and…

### DIFF
--- a/beam-core/Database/Beam/Query/Operator.hs
+++ b/beam-core/Database/Beam/Query/Operator.hs
@@ -59,16 +59,18 @@ infixr 3 &&., &&?.
 infixr 2 ||., ||?.
 
 -- | SQL @LIKE@ operator
-like_ :: ( BeamSqlBackendIsString be text
+like_ :: ( BeamSqlBackendIsString be left
+         , BeamSqlBackendIsString be right
          , BeamSqlBackend be )
-      => QGenExpr ctxt be s text -> QGenExpr ctxt be s text -> QGenExpr ctxt be s Bool
+      => QGenExpr ctxt be s left -> QGenExpr ctxt be s right -> QGenExpr ctxt be s Bool
 like_ (QExpr scrutinee) (QExpr search) =
   QExpr (liftA2 likeE scrutinee search)
 
 -- | SQL99 @SIMILAR TO@ operator
-similarTo_ :: ( BeamSqlBackendIsString be text
+similarTo_ :: ( BeamSqlBackendIsString be left
+              , BeamSqlBackendIsString be right
               , BeamSql99ExpressionBackend be )
-           => QGenExpr ctxt be s text -> QGenExpr ctxt be s text -> QGenExpr ctxt be s text
+           => QGenExpr ctxt be s left -> QGenExpr ctxt be s right -> QGenExpr ctxt be s left
 similarTo_ (QExpr scrutinee) (QExpr search) =
   QExpr (liftA2 similarToE scrutinee search)
 

--- a/beam-postgres/Database/Beam/Postgres/PgSpecific.hs
+++ b/beam-postgres/Database/Beam/Postgres/PgSpecific.hs
@@ -164,9 +164,11 @@ now_ :: QExpr Postgres s LocalTime
 now_ = QExpr (\_ -> PgExpressionSyntax (emit "NOW()"))
 
 -- | Postgres @ILIKE@ operator. A case-insensitive version of 'like_'.
-ilike_ :: BeamSqlBackendIsString Postgres text
-       => QExpr Postgres s text
-       -> QExpr Postgres s text
+ilike_ :: ( BeamSqlBackendIsString Postgres left
+          , BeamSqlBackendIsString Postgres right
+          )
+       => QExpr Postgres s left
+       -> QExpr Postgres s right
        -> QExpr Postgres s Bool
 ilike_ (QExpr a) (QExpr b) = QExpr (pgBinOp "ILIKE" <$> a <*> b)
 
@@ -1551,4 +1553,3 @@ instance HasDefaultSqlDataType Postgres a
 -- 'pgUnnestArrayWithOrdinality' function allows you to join against the
 -- elements of an array along with its index. This corresponds to the
 -- @UNNEST .. WITH ORDINALITY@ clause.
-


### PR DESCRIPTION
… needle

Suppose you have a have strongly typed column URL and want to use like_, ilike_ or similarTo_ to query for a pattern of type Text. Currently that is not possible to express with Beam since e.g. creating an invalid URL from your pattern Text is not always an option - and that's what this patch fixes.