### PR TITLE
Release beam-core 0.9.1.0; beam-migrate, beam-postgres, beam-sqlite 0.5.1.0

### DIFF
--- a/beam-core/ChangeLog.md
+++ b/beam-core/ChangeLog.md
@@ -1,3 +1,9 @@
+# 0.9.1.0
+
+## Added features
+
+ * Improve error message when `asc_` or `desc_` is missing in `orderBy_`
+
 # 0.9.0.0
 
 ## Removal of machine-dependent `Int`/`Word` instances

--- a/beam-core/beam-core.cabal
+++ b/beam-core/beam-core.cabal
@@ -2,7 +2,7 @@
 -- see http://haskell.org/cabal/users-guide/
 
 name:                beam-core
-version:             0.9.0.0
+version:             0.9.1.0
 synopsis:            Type-safe, feature-complete SQL query and manipulation interface for Haskell
 description:         Beam is a Haskell library for type-safe querying and manipulation of SQL databases.
                      Beam is modular and supports various backends. In order to use beam, you will need to use

--- a/beam-migrate/ChangeLog.md
+++ b/beam-migrate/ChangeLog.md
@@ -1,3 +1,13 @@
+# 0.5.1.0
+
+## Added features
+
+ * Expose `IsNotNull` class
+
+## Bug fixes
+
+ * Order log entries when verifying migration status
+
 # 0.5.0.0
 
 ## Interface changes

--- a/beam-migrate/beam-migrate.cabal
+++ b/beam-migrate/beam-migrate.cabal
@@ -1,5 +1,5 @@
 name:                beam-migrate
-version:             0.5.0.0
+version:             0.5.1.0
 synopsis:            SQL DDL support and migrations support library for Beam
 description:         This package provides type classes to allow backends to implement
                      SQL DDL support for beam. This allows you to use beam syntax to

--- a/beam-postgres/ChangeLog.md
+++ b/beam-postgres/ChangeLog.md
@@ -1,3 +1,14 @@
+# 0.5.1.0
+
+## Added features
+
+ * `MonadBase` and `MonadBaseControl` instances for `Pg`
+
+## Bug fixes
+
+ * Fix possible memory corruption by copying row data
+ * Remove invalid parentheses emitted by `pgUnnest`
+
 # 0.5.0.0
 
 ## Interface changes

--- a/beam-postgres/beam-postgres.cabal
+++ b/beam-postgres/beam-postgres.cabal
@@ -1,5 +1,5 @@
 name:                 beam-postgres
-version:              0.5.0.0
+version:              0.5.1.0
 synopsis:             Connection layer between beam and postgres
 description:          Beam driver for <https://www.postgresql.org/ PostgreSQL>, an advanced open-source RDBMS
 homepage:             https://haskell-beam.github.io/beam/user-guide/backends/beam-postgres

--- a/beam-sqlite/ChangeLog.md
+++ b/beam-sqlite/ChangeLog.md
@@ -1,6 +1,11 @@
+# 0.5.1.0
+
+## Added features
+
+ * `MonadBase` and `MonadBaseControl` instances for `SqliteM`
+
 # 0.5.0.0
 
-=======
 ## Interface changes
 
  * Removed instances for machine-dependent ambiguous integer types `Int` and `Word`

--- a/beam-sqlite/beam-sqlite.cabal
+++ b/beam-sqlite/beam-sqlite.cabal
@@ -1,5 +1,5 @@
 name:                beam-sqlite
-version:             0.5.0.0
+version:             0.5.1.0
 synopsis:            Beam driver for SQLite
 description:         Beam driver for the <https://sqlite.org/ SQLite> embedded database.
                      See <https://haskell-beam.github.io/beam/user-guide/backends/beam-sqlite/ here>


### PR DESCRIPTION
This is a retroactive release (branched off 77c44566d641a38d7df9b15cac5bb8de895e1e36) of bug fixes and backwards compatible feature additions for each package.

Soon we'll do another release off master including breaking changes.

Fixes #565.