### PR TITLE
Make variants for heterogeneous like_/similarTo_/ilike_ and restore originals

### DIFF
--- a/beam-core/Database/Beam/Query/Operator.hs
+++ b/beam-core/Database/Beam/Query/Operator.hs
@@ -6,6 +6,7 @@ module Database.Beam.Query.Operator
   , (&&?.), (||?.), sqlNot_
 
   , like_, similarTo_
+  , like_', similarTo_'
 
   , concat_
   ) where
@@ -59,19 +60,43 @@ infixr 3 &&., &&?.
 infixr 2 ||., ||?.
 
 -- | SQL @LIKE@ operator
-like_ :: ( BeamSqlBackendIsString be left
-         , BeamSqlBackendIsString be right
-         , BeamSqlBackend be )
-      => QGenExpr ctxt be s left -> QGenExpr ctxt be s right -> QGenExpr ctxt be s Bool
-like_ (QExpr scrutinee) (QExpr search) =
+like_
+  :: (BeamSqlBackendIsString be text, BeamSqlBackend be)
+  => QGenExpr ctxt be s text
+  -> QGenExpr ctxt be s text
+  -> QGenExpr ctxt be s Bool
+like_ = like_'
+
+-- | SQL @LIKE@ operator but heterogeneous over the text type
+like_'
+  :: ( BeamSqlBackendIsString be left
+     , BeamSqlBackendIsString be right
+     , BeamSqlBackend be
+     )
+  => QGenExpr ctxt be s left
+  -> QGenExpr ctxt be s right
+  -> QGenExpr ctxt be s Bool
+like_' (QExpr scrutinee) (QExpr search) =
   QExpr (liftA2 likeE scrutinee search)
 
 -- | SQL99 @SIMILAR TO@ operator
-similarTo_ :: ( BeamSqlBackendIsString be left
-              , BeamSqlBackendIsString be right
-              , BeamSql99ExpressionBackend be )
-           => QGenExpr ctxt be s left -> QGenExpr ctxt be s right -> QGenExpr ctxt be s left
-similarTo_ (QExpr scrutinee) (QExpr search) =
+similarTo_
+  :: (BeamSqlBackendIsString be text, BeamSql99ExpressionBackend be)
+  => QGenExpr ctxt be s text
+  -> QGenExpr ctxt be s text
+  -> QGenExpr ctxt be s text
+similarTo_ = similarTo_'
+
+-- | SQL99 @SIMILAR TO@ operator but heterogeneous over the text type
+similarTo_'
+  :: ( BeamSqlBackendIsString be left
+     , BeamSqlBackendIsString be right
+     , BeamSql99ExpressionBackend be
+     )
+  => QGenExpr ctxt be s left
+  -> QGenExpr ctxt be s right
+  -> QGenExpr ctxt be s left
+similarTo_' (QExpr scrutinee) (QExpr search) =
   QExpr (liftA2 similarToE scrutinee search)
 
 infix 4 `like_`, `similarTo_`

--- a/beam-postgres/Database/Beam/Postgres/PgSpecific.hs
+++ b/beam-postgres/Database/Beam/Postgres/PgSpecific.hs
@@ -111,7 +111,7 @@ module Database.Beam.Postgres.PgSpecific
 
   , pgNubBy_
 
-  , now_, ilike_
+  , now_, ilike_, ilike_'
   )
 where
 
@@ -164,13 +164,22 @@ now_ :: QExpr Postgres s LocalTime
 now_ = QExpr (\_ -> PgExpressionSyntax (emit "NOW()"))
 
 -- | Postgres @ILIKE@ operator. A case-insensitive version of 'like_'.
-ilike_ :: ( BeamSqlBackendIsString Postgres left
-          , BeamSqlBackendIsString Postgres right
-          )
-       => QExpr Postgres s left
-       -> QExpr Postgres s right
-       -> QExpr Postgres s Bool
-ilike_ (QExpr a) (QExpr b) = QExpr (pgBinOp "ILIKE" <$> a <*> b)
+ilike_
+  :: BeamSqlBackendIsString Postgres text
+  => QExpr Postgres s text
+  -> QExpr Postgres s text
+  -> QExpr Postgres s Bool
+ilike_ = ilike_'
+
+-- | Postgres @ILIKE@ operator. A case-insensitive version of 'like_''.
+ilike_'
+  :: ( BeamSqlBackendIsString Postgres left
+     , BeamSqlBackendIsString Postgres right
+     )
+  => QExpr Postgres s left
+  -> QExpr Postgres s right
+  -> QExpr Postgres s Bool
+ilike_' (QExpr a) (QExpr b) = QExpr (pgBinOp "ILIKE" <$> a <*> b)
 
 -- ** TsVector type
 


### PR DESCRIPTION
Some experience with #562 suggests that it causes too much breakage since often the haystack string is static and then it needs a type annotation since it can't just unify with the needle.

I'm not a big fan of just appending `'` so these are hopefully just placeholder names until I can think of something not too clunky.