### PR TITLE
Export generic classes

### DIFF
--- a/beam-core/Database/Beam/Backend/SQL/Row.hs
+++ b/beam-core/Database/Beam/Backend/SQL/Row.hs
@@ -13,6 +13,9 @@ module Database.Beam.Backend.SQL.Row
   , ColumnParseError(..), BeamRowReadError(..)
 
   , FromBackendRow(..)
+
+    -- * Exported so we can override defaults
+  , GFromBackendRow(..) -- for 'runSelectReturningList' and co
   ) where
 
 import           Database.Beam.Backend.SQL.Types

--- a/beam-core/Database/Beam/Schema/Lenses.hs
+++ b/beam-core/Database/Beam/Schema/Lenses.hs
@@ -4,7 +4,12 @@ module Database.Beam.Schema.Lenses
     ( tableLenses
     , TableLens(..)
 
-    , dbLenses ) where
+    , dbLenses
+
+    -- * Exported so we can override defaults
+    , GTableLenses(..)
+    , GDatabaseLenses(..)
+    ) where
 
 import Database.Beam.Schema.Tables
 

--- a/beam-core/Database/Beam/Schema/Tables.hs
+++ b/beam-core/Database/Beam/Schema/Tables.hs
@@ -57,7 +57,20 @@ module Database.Beam.Schema.Tables
     , pk
     , allBeamValues, changeBeamRep
     , alongsideTable
-    , defaultFieldName )
+    , defaultFieldName
+
+    -- * Exported so we can override defaults
+    -- For 'Beamable'
+    , GZipTables(..)
+    , GTableSkeleton(..)
+    -- For 'Database'
+    , GZipDatabase(..)
+    -- for 'defaultDbSettings'
+    , GAutoDbSettings(..)
+    , GDefaultTableFieldSettings(..)
+    , ChooseSubTableStrategy
+    , SubTableStrategyImpl
+    )
     where
 
 import           Database.Beam.Backend.Types


### PR DESCRIPTION
`beam` relies very heavily on GHC generics, but the standard GHC generic instances are not appropriate for all use cases (motivating example in this case being [`large-records`](https://hackage.haskell.org/package/large-records)). Fortunately, the way GHC generics is set up allows us to use non-standard representations, _provided_ that we can then define additional instances for whatever generic classes are necessary. The [`beam-large-records`](https://github.com/well-typed/beam-large-records) library provides integration for `large-records` with `beam-core`, by providing these additional instances, but this does mean that the generic classes must be _exported_ from `beam-core` so that additional instances can be provided. This commit adds these exports.