### PR TITLE
Postgres.Conduit: throw SqlError when row is error

### DIFF
--- a/beam-postgres/Database/Beam/Postgres/Conduit.hs
+++ b/beam-postgres/Database/Beam/Postgres/Conduit.hs
@@ -233,6 +233,9 @@ streamResults (conn@Pg.Connection {connectionHandle}) conn' fields = do
         Pg.TuplesOk -> liftIO (finishQuery conn')
         Pg.EmptyQuery -> Fail.fail "No query"
         Pg.CommandOk -> pure ()
+        status@Pg.BadResponse -> liftIO (Pg.throwResultError "streamResults" row status)
+        status@Pg.NonfatalError -> liftIO (Pg.throwResultError "streamResults" row status)
+        status@Pg.FatalError -> liftIO (Pg.throwResultError "streamResults" row status)
         _ -> do errMsg <- liftIO (Pg.resultErrorMessage row)
                 Fail.fail ("Postgres error: " <> show errMsg)
 


### PR DESCRIPTION
Fixes #596 

Sadly I don't have a good reproducer for serialization errors, but I'm confident that this is the correct fix, based on the fact the error message had `Postgres error:` which only occurs on the line below. The three matches correspond to how postgresql-simple uses `throwResultError`.