### PR TITLE
Compiles with aeson 2.0+

### DIFF
--- a/beam-core/beam-core.cabal
+++ b/beam-core/beam-core.cabal
@@ -61,7 +61,8 @@ library
                        Database.Beam.Schema.Lenses
 
   build-depends:       base         >=4.9     && <5.0,
-                       aeson        >=0.11    && <1.6,
+--                       aeson        >=0.11    && <1.6,
+                       aeson        >=0.11    && <2.1,
                        text         >=1.2.2.0 && <1.3,
                        bytestring   >=0.10    && <0.12,
                        mtl          >=2.2.1   && <2.3,

--- a/beam-migrate-cli/beam-migrate-cli.cabal
+++ b/beam-migrate-cli/beam-migrate-cli.cabal
@@ -42,7 +42,7 @@ executable beam-migrate
                        containers           >=0.5      && <0.7,
                        unordered-containers >=0.2      && <0.3,
                        hashable             >=1.2      && <1.5,
-                       aeson                >=0.11     && <1.6,
+                       aeson                >=0.11     && <2.1,
                        unix                 >=2.7      && <2.8,
                        network              >=2.6      && <3.2,
                        hostname             >=1.0      && <=2.0,

--- a/beam-migrate/Database/Beam/Migrate/Serialization.hs
+++ b/beam-migrate/Database/Beam/Migrate/Serialization.hs
@@ -39,6 +39,9 @@ import           Control.Applicative
 import           Control.Monad
 
 import           Data.Aeson
+#if MIN_VERSION_aeson(2,0,0)
+import Data.Aeson.Key (fromText)
+#endif
 import           Data.Aeson.Types (Parser)
 import qualified Data.Dependent.Map as D
 import qualified Data.GADT.Compare as D
@@ -322,8 +325,11 @@ sql92Deserializers = mconcat
                    , beamDeserializer deserializeSql92Attributes ]
   where
     parseSub nm o key parse =
+#if MIN_VERSION_aeson(2,0,0)
+      withObject (unpack (nm <> "." <> key)) parse =<< o .: fromText key
+#else
       withObject (unpack (nm <> "." <> key)) parse =<< o .: key
-
+#endif
     deserializeSql92DataType :: BeamDeserializers be' -> Value
                              -> Parser (BeamSqlBackendDataTypeSyntax be)
     deserializeSql92DataType _ o =

--- a/beam-migrate/beam-migrate.cabal
+++ b/beam-migrate/beam-migrate.cabal
@@ -62,7 +62,7 @@ library
   build-depends:       base                 >=4.9     && <5.0,
                        beam-core            >=0.9     && <0.10,
                        text                 >=1.2     && <1.3,
-                       aeson                >=0.11    && <1.6,
+                       aeson                >=0.11    && <2.1,
                        bytestring           >=0.10    && <0.12,
                        free                 >=4.12    && <5.2,
                        time                 >=1.6     && <1.12,

--- a/beam-postgres/beam-postgres.cabal
+++ b/beam-postgres/beam-postgres.cabal
@@ -50,7 +50,7 @@ library
                       monad-control        >=1.0  && <1.1,
                       mtl                  >=2.1  && <2.3,
                       conduit              >=1.2  && <1.4,
-                      aeson                >=0.11 && <1.6,
+                      aeson                >=0.11 && <2.1,
                       uuid-types           >=1.0  && <1.1,
                       case-insensitive     >=1.2  && <1.3,
                       scientific           >=0.3  && <0.4,

--- a/beam-sqlite/beam-sqlite.cabal
+++ b/beam-sqlite/beam-sqlite.cabal
@@ -39,7 +39,7 @@ library
                       scientific    >=0.3  && <0.4,
                       monad-control        >=1.0  && <1.1,
                       network-uri   >=2.6  && <2.7,
-                      aeson         >=0.11 && <1.6,
+                      aeson         >=0.11 && <2.1,
                       attoparsec    >=0.13 && <0.15,
                       transformers-base    >=0.4  && <0.5
   default-language:   Haskell2010


### PR DESCRIPTION
Not sure this is all that's necessary.  Nor did I know how to test.  But I bumped the dependencies in all cabal files and added the small bit of CPP to make things work in beam-migrate.