### PR TITLE
Test aeson 2.0 build in CI

### DIFF
--- a/nix/lib.nix
+++ b/nix/lib.nix
@@ -54,6 +54,10 @@ rec {
           sha256 = "0x3yyq4vdpz4rqymbrq70swjpi0k6bnja0vhwlpgbgpzdb3ij7vc";
         };
       })
+      (self: _: {
+        # This is not needed, but it tests the version bounds:
+        aeson = self.aeson_2_0_1_0;
+      })
     ]);
   };
 


### PR DESCRIPTION
Follow up to #617. This makes sure that the compatibility CPP works.

It looks like `aeson_2_0_1_0` from the package set has some extra fixes that aren't picked up with just `pinHackageVersions`, which is why that isn't used.