### PR TITLE
beam-postgres: bool_any -> bool_or

### DIFF
--- a/beam-postgres/Database/Beam/Postgres/Syntax.hs
+++ b/beam-postgres/Database/Beam/Postgres/Syntax.hs
@@ -921,8 +921,8 @@ instance IsSql99AggregationExpressionSyntax PgExpressionSyntax where
 
   -- According to the note at <https://www.postgresql.org/docs/9.2/static/functions-aggregate.html>
   -- the following functions are equivalent.
-  someE = pgUnAgg "BOOL_ANY"
-  anyE = pgUnAgg "BOOL_ANY"
+  someE = pgUnAgg "BOOL_OR"
+  anyE = pgUnAgg "BOOL_OR"
 
 instance IsSql92AggregationSetQuantifierSyntax PgAggregationSetQuantifierSyntax where
   setQuantifierDistinct = PgAggregationSetQuantifierSyntax $ emit "DISTINCT"


### PR DESCRIPTION
bool_any does not actually exist. Somehow this hasn't been noticed until now