### PR TITLE
Fix compilation with ghc-9.4

### DIFF
--- a/beam-core/Database/Beam/Query/Combinators.hs
+++ b/beam-core/Database/Beam/Query/Combinators.hs
@@ -854,7 +854,7 @@ instance ( BeamSqlBackend be, Beamable t)
     isNothing_ t = allE (allBeamValues (\(Columnar' e) -> isNothing_ e) t)
     maybe_ (QExpr onNothing) onJust tbl =
       let QExpr onJust' = onJust (changeBeamRep (\(Columnar' (QExpr e)) -> Columnar' (QExpr e)) tbl)
-          QExpr cond = isJust_ tbl
+          QExpr cond = isJust_ @be tbl
       in QExpr (\tblPfx -> caseE [(cond tblPfx, onJust' tblPfx)] (onNothing tblPfx))
 
 infixl 3 <|>.


### PR DESCRIPTION
This allows ghc-9.4 to infer the types properly. 

This PR doesn't make beam fully compatible with ghc-9.4 as some dependency bumps are still required. 