### PR TITLE
update `hint` fix version; fix multiple `sha256`; update `nixpkgs`

### DIFF
--- a/beam-migrate-cli/beam-migrate-cli.cabal
+++ b/beam-migrate-cli/beam-migrate-cli.cabal
@@ -33,7 +33,7 @@ executable beam-migrate
                        text                 >=1.2      && <2.1,
                        bytestring           >=0.10     && <0.12,
                        time                 >=1.6      && <1.13,
-                       optparse-applicative >=0.13     && <0.17,
+                       optparse-applicative >=0.13     && <0.18,
                        directory            >=1.2      && <1.4,
                        filepath             >=1.4      && <1.5,
                        largeword            >=1.2      && <1.3,

--- a/docs/default.nix
+++ b/docs/default.nix
@@ -11,14 +11,14 @@ let
   };
   chinookPostgresRaw = fetchurl {
     url = "https://raw.githubusercontent.com/lerocha/chinook-database/master/ChinookDatabase/DataSources/Chinook_PostgreSql.sql";
-    sha256 = "6945d59e3bca94591e2a96451b9bd69084b026f7fb7dbda3d15d06114ffb34c4";
+    sha256 = "sha256-CVQAyq0WlAn7+0d72nsm9krVDLtMA1QcgHJhwdttNC4=";
   };
   chinookPostgres = runCommand "chinook-postgres" {} ''
     ${glibc.bin}/bin/iconv -f ISO-8859-2 -t UTF-8 ${chinookPostgresRaw} > $out
   '';
   chinookSqliteRaw = fetchurl {
     url = "https://raw.githubusercontent.com/lerocha/chinook-database/master/ChinookDatabase/DataSources/Chinook_Sqlite.sql";
-    sha256 = "b2e430ec8cb389509d25ec5bda2f958bbf6f0ca42e276fa5eb3de45eb816a460";
+    sha256 = "sha256-Zu+IP8fhmYwpgofjtMJLvL8jFRlKJ43mjLANivq6Q9s=";
   };
   chinookSqlite = runCommand "chinook-sqlite" {} ''
     tail -c +4 ${chinookSqliteRaw} > $out

--- a/docs/default.nix
+++ b/docs/default.nix
@@ -10,7 +10,7 @@ let
     projectDir = ./.;
   };
   chinookPostgresRaw = fetchurl {
-    url = "https://raw.githubusercontent.com/lerocha/chinook-database/master/ChinookDatabase/DataSources/Chinook_PostgreSql.sql";
+    url = "https://raw.githubusercontent.com/lerocha/chinook-database/e7e6d5f008e35d3f89d8b8a4f8d38e3bfa7e34bd/ChinookDatabase/DataSources/Chinook_PostgreSql.sql";
     sha256 = "sha256-CVQAyq0WlAn7+0d72nsm9krVDLtMA1QcgHJhwdttNC4=";
   };
   chinookPostgres = runCommand "chinook-postgres" {} ''

--- a/docs/default.nix
+++ b/docs/default.nix
@@ -17,7 +17,7 @@ let
     ${glibc.bin}/bin/iconv -f ISO-8859-2 -t UTF-8 ${chinookPostgresRaw} > $out
   '';
   chinookSqliteRaw = fetchurl {
-    url = "https://raw.githubusercontent.com/lerocha/chinook-database/master/ChinookDatabase/DataSources/Chinook_Sqlite.sql";
+    url = "https://raw.githubusercontent.com/lerocha/chinook-database/e7e6d5f008e35d3f89d8b8a4f8d38e3bfa7e34bd/ChinookDatabase/DataSources/Chinook_Sqlite.sql";
     sha256 = "sha256-Zu+IP8fhmYwpgofjtMJLvL8jFRlKJ43mjLANivq6Q9s=";
   };
   chinookSqlite = runCommand "chinook-sqlite" {} ''

--- a/nix/lib.nix
+++ b/nix/lib.nix
@@ -51,7 +51,7 @@ rec {
         hint = {
           pkg = "hint";
           ver = "0.9.0.6";
-          sha256 = "1j7jzx8i1rc66xw4c6gf4kjv0a8ma96j25kfz6rzswik4vp5xmky";
+          sha256 = "sha256-6IahCrVNaryAInmEVKHr3xjXmjc0dYXQs+KvEHt33+w=";
         };
       })
       (self: _: {

--- a/nix/lib.nix
+++ b/nix/lib.nix
@@ -13,25 +13,14 @@ rec {
     "beam-migrate-cli"
   ];
   ghcVersions = {
-    ghc865 = haskell.packages.ghc865Binary.extend (composeExtensionList [
-      (_: super: {
-       # Similar weird library issue as with beam-migrate-cli:
-        constraints-extras = haskell.lib.disableCabalFlag
-          super.constraints-extras
-          "build-readme";
-      })
-      (applyToPackages haskell.lib.doJailbreak [
-        "mono-traversable"
-      ])
-    ]);
     inherit (haskell.packages) ghc884;
     inherit (haskell.packages) ghc8107;
-    ghc901 = haskell.packages.ghc901.extend (composeExtensionList [
+    ghc902 = haskell.packages.ghc902.extend (composeExtensionList [
       (applyToPackages haskell.lib.doJailbreak [
         "pqueue"
       ])
     ]);
-    ghc921 = haskell.packages.ghc921.extend (composeExtensionList [
+    ghc925 = haskell.packages.ghc925.extend (composeExtensionList [
       (applyToPackages haskell.lib.doJailbreak [
         "postgresql-libpq"
         "postgresql-simple"
@@ -56,7 +45,7 @@ rec {
       })
       (self: _: {
         # This is not needed, but it tests the version bounds:
-        aeson = self.aeson_2_0_1_0;
+        aeson = self.aeson_2_1_1_0;
       })
     ]);
   };

--- a/nix/lib.nix
+++ b/nix/lib.nix
@@ -31,18 +31,6 @@ rec {
         # This is not needed, but it tests the version bounds:
         "vector-sized" = "1.5.0";
       })
-      (pinHackageDirectVersions {
-        constraints-extras = {
-          pkg = "constraints-extras";
-          ver = "0.3.2.1";
-          sha256 = "03hsja50vzflqqmvvxgc9w32dqg51dlw8i0blpqb2ipv7njx4q2q";
-        };
-        hint = {
-          pkg = "hint";
-          ver = "0.9.0.6";
-          sha256 = "sha256-6IahCrVNaryAInmEVKHr3xjXmjc0dYXQs+KvEHt33+w=";
-        };
-      })
       (self: _: {
         # This is not needed, but it tests the version bounds:
         aeson = self.aeson_2_1_1_0;

--- a/nix/lib.nix
+++ b/nix/lib.nix
@@ -50,8 +50,8 @@ rec {
         };
         hint = {
           pkg = "hint";
-          ver = "0.9.0.5";
-          sha256 = "0x3yyq4vdpz4rqymbrq70swjpi0k6bnja0vhwlpgbgpzdb3ij7vc";
+          ver = "0.9.0.6";
+          sha256 = "1j7jzx8i1rc66xw4c6gf4kjv0a8ma96j25kfz6rzswik4vp5xmky";
         };
       })
       (self: _: {

--- a/nix/nixpkgs.nix
+++ b/nix/nixpkgs.nix
@@ -1,4 +1,4 @@
 import (builtins.fetchTarball {
-    url = "https://github.com/NixOS/nixpkgs/tarball/86453059bf8312f0f5bf1fe8a2f52da2be664489";
-    sha256 = "0inzy97dp5988cwjwpn41219rir4c7qp7wwg7v4abcs9lypg8is4";
+    url = "https://github.com/NixOS/nixpkgs/tarball/7875a11bd6ed9b70de960a70724c1a4f90dc1ea8";
+    sha256 = "1062r7q0723paxpg5ifmmirm8n0gp2sdrhfipldz1h0980pv29h8";
 })

--- a/shell.nix
+++ b/shell.nix
@@ -11,6 +11,6 @@ in beamGhc.shellFor {
   packages = beamLib.beamPackageList;
   nativeBuildInputs = [
     postgresql
-    sqliteInteractive
+    sqlite-interactive
   ];
 }


### PR DESCRIPTION
Update `hint` fix version. The current version used is deprecated: https://hackage.haskell.org/package/hint-0.9.0.6/changelog

Default GHC updated from 8.10 to 9.2

`docs` needs to be fixed, otherwise `nix-build release.nix` succeeds.

Pinned `nixpkgs` commit: https://github.com/NixOS/nixpkgs/commit/7875a11bd6ed9b70de960a70724c1a4f90dc1ea8

--------------

~The `sha256` is wrong; `nix-build release.nix` fails. How do I acquire the correct SHA?~

~The values returned by both of these commands are wrong:~
```
 $ nix-prefetch-url https://hackage.haskell.org/package/hint-0.9.0.6/hint-0.9.0.6.tar.gz
 1j7jzx8i1rc66xw4c6gf4kjv0a8ma96j25kfz6rzswik4vp5xmky
 
 ```
 
