### PR TITLE
beam-migrate-cli: Loosen cryptonite upper bound

### DIFF
--- a/beam-migrate-cli/beam-migrate-cli.cabal
+++ b/beam-migrate-cli/beam-migrate-cli.cabal
@@ -52,7 +52,7 @@ executable beam-migrate
                        random               >=1.1      && <1.3,
                        ansi-terminal        >=0.6      && <0.12,
                        haskell-src-exts     >=1.18     && <1.24,
-                       cryptonite           >=0.23     && <0.30,
+                       cryptonite           >=0.23     && <0.31,
                        monad-loops          >=0.4      && <0.5,
                        exceptions           >=0.8      && <0.11,
                        editor-open          >=0.6      && <0.7,


### PR DESCRIPTION
Ran into a build failure due to not being able to resolve `cryptonite`.

![image](https://user-images.githubusercontent.com/20364796/208941795-a4529805-f699-4441-af98-4e89793638d1.png)

Bumping it to `<0.31` allows it to build.
