### PR TITLE
update `nixpkgs`

### DIFF
--- a/beam-migrate-cli/beam-migrate-cli.cabal
+++ b/beam-migrate-cli/beam-migrate-cli.cabal
@@ -33,7 +33,7 @@ executable beam-migrate
                        text                 >=1.2      && <2.1,
                        bytestring           >=0.10     && <0.12,
                        time                 >=1.6      && <1.13,
-                       optparse-applicative >=0.13     && <0.17,
+                       optparse-applicative >=0.13     && <0.18,
                        directory            >=1.2      && <1.4,
                        filepath             >=1.4      && <1.5,
                        largeword            >=1.2      && <1.3,

--- a/docs/default.nix
+++ b/docs/default.nix
@@ -10,15 +10,15 @@ let
     projectDir = ./.;
   };
   chinookPostgresRaw = fetchurl {
-    url = "https://raw.githubusercontent.com/lerocha/chinook-database/master/ChinookDatabase/DataSources/Chinook_PostgreSql.sql";
-    sha256 = "6945d59e3bca94591e2a96451b9bd69084b026f7fb7dbda3d15d06114ffb34c4";
+    url = "https://raw.githubusercontent.com/lerocha/chinook-database/e7e6d5f008e35d3f89d8b8a4f8d38e3bfa7e34bd/ChinookDatabase/DataSources/Chinook_PostgreSql.sql";
+    sha256 = "sha256-CVQAyq0WlAn7+0d72nsm9krVDLtMA1QcgHJhwdttNC4=";
   };
   chinookPostgres = runCommand "chinook-postgres" {} ''
     ${glibc.bin}/bin/iconv -f ISO-8859-2 -t UTF-8 ${chinookPostgresRaw} > $out
   '';
   chinookSqliteRaw = fetchurl {
-    url = "https://raw.githubusercontent.com/lerocha/chinook-database/master/ChinookDatabase/DataSources/Chinook_Sqlite.sql";
-    sha256 = "b2e430ec8cb389509d25ec5bda2f958bbf6f0ca42e276fa5eb3de45eb816a460";
+    url = "https://raw.githubusercontent.com/lerocha/chinook-database/e7e6d5f008e35d3f89d8b8a4f8d38e3bfa7e34bd/ChinookDatabase/DataSources/Chinook_Sqlite.sql";
+    sha256 = "sha256-Zu+IP8fhmYwpgofjtMJLvL8jFRlKJ43mjLANivq6Q9s=";
   };
   chinookSqlite = runCommand "chinook-sqlite" {} ''
     tail -c +4 ${chinookSqliteRaw} > $out

--- a/nix/lib.nix
+++ b/nix/lib.nix
@@ -13,25 +13,14 @@ rec {
     "beam-migrate-cli"
   ];
   ghcVersions = {
-    ghc865 = haskell.packages.ghc865Binary.extend (composeExtensionList [
-      (_: super: {
-       # Similar weird library issue as with beam-migrate-cli:
-        constraints-extras = haskell.lib.disableCabalFlag
-          super.constraints-extras
-          "build-readme";
-      })
-      (applyToPackages haskell.lib.doJailbreak [
-        "mono-traversable"
-      ])
-    ]);
     inherit (haskell.packages) ghc884;
     inherit (haskell.packages) ghc8107;
-    ghc901 = haskell.packages.ghc901.extend (composeExtensionList [
+    ghc902 = haskell.packages.ghc902.extend (composeExtensionList [
       (applyToPackages haskell.lib.doJailbreak [
         "pqueue"
       ])
     ]);
-    ghc921 = haskell.packages.ghc921.extend (composeExtensionList [
+    ghc925 = haskell.packages.ghc925.extend (composeExtensionList [
       (applyToPackages haskell.lib.doJailbreak [
         "postgresql-libpq"
         "postgresql-simple"
@@ -56,7 +45,7 @@ rec {
       })
       (self: _: {
         # This is not needed, but it tests the version bounds:
-        aeson = self.aeson_2_0_1_0;
+        aeson = self.aeson_2_1_1_0;
       })
     ]);
   };

--- a/nix/nixpkgs.nix
+++ b/nix/nixpkgs.nix
@@ -1,4 +1,4 @@
 import (builtins.fetchTarball {
-    url = "https://github.com/NixOS/nixpkgs/tarball/86453059bf8312f0f5bf1fe8a2f52da2be664489";
-    sha256 = "0inzy97dp5988cwjwpn41219rir4c7qp7wwg7v4abcs9lypg8is4";
+    url = "https://github.com/NixOS/nixpkgs/tarball/7875a11bd6ed9b70de960a70724c1a4f90dc1ea8";
+    sha256 = "1062r7q0723paxpg5ifmmirm8n0gp2sdrhfipldz1h0980pv29h8";
 })

--- a/shell.nix
+++ b/shell.nix
@@ -11,6 +11,6 @@ in beamGhc.shellFor {
   packages = beamLib.beamPackageList;
   nativeBuildInputs = [
     postgresql
-    sqliteInteractive
+    sqlite-interactive
   ];
 }


### PR DESCRIPTION
Default GHC updated from 8.10 to 9.2

`docs` needs to be fixed, otherwise `nix-build release.nix` succeeds.

https://github.com/NixOS/nixpkgs/commit/7875a11bd6ed9b70de960a70724c1a4f90dc1ea8

Includes these fixes:
- https://github.com/haskell-beam/beam/pull/650#discussion_r1051660126 
- https://github.com/haskell-beam/beam/pull/650#discussion_r1051660155

---------------------

There are several compile errors in `docs`, like:

```
/build/runghcXXXX364-0.hs:96:38: error:
    • Couldn't match expected type ‘p3’
                  with actual type ‘Lens' (UserT f0) (Columnar f0 Text)’
      Cannot equate type variable ‘p3’
      with a type involving polytypes:
        Lens' (UserT f0) (Columnar f0 Text)
      ‘p3’ is a rigid type variable bound by
        the inferred types of
          userEmail :: p
          userFirstName :: p1
          userLastName :: p2
          userPassword :: p3
        at /build/runghcXXXX364-0.hs:(95,1)-(97,16)
    • In the pattern: LensFor userPassword
      In the pattern:
        User (LensFor userEmail) (LensFor userFirstName)
             (LensFor userLastName) (LensFor userPassword)
      In a pattern binding:
        User (LensFor userEmail) (LensFor userFirstName)
             (LensFor userLastName) (LensFor userPassword)
          = tableLenses
   |
96 |      (LensFor userLastName) (LensFor userPassword) =
   |                                      ^^^^^^^^^^^^
```

Can someone help me with these errors?
