### PR TITLE
Upgrade to nixpkgs 23.05 and test up to GHC 9.2

### DIFF
--- a/beam-migrate-cli/beam-migrate-cli.cabal
+++ b/beam-migrate-cli/beam-migrate-cli.cabal
@@ -33,7 +33,7 @@ executable beam-migrate
                        text                 >=1.2      && <2.1,
                        bytestring           >=0.10     && <0.12,
                        time                 >=1.6      && <1.13,
-                       optparse-applicative >=0.13     && <0.17,
+                       optparse-applicative >=0.13     && <0.18,
                        directory            >=1.2      && <1.4,
                        filepath             >=1.4      && <1.5,
                        largeword            >=1.2      && <1.3,

--- a/nix/lib.nix
+++ b/nix/lib.nix
@@ -6,61 +6,17 @@ rec {
     "beam-migrate"
     "beam-postgres"
     "beam-sqlite"
-  ] ++ lib.optionals (ghc.ghc.version != "8.6.5") [
-    # For unclear reasons, this fails to build on 8.6.5 with missing dynamic
-    # libraries. It's probably somehow related to it being a binary GHC
-    # distribution as opposed to built normally with nix.
     "beam-migrate-cli"
   ];
   ghcVersions = {
-    ghc865 = haskell.packages.ghc865Binary.extend (composeExtensionList [
-      (_: super: {
-       # Similar weird library issue as with beam-migrate-cli:
-        constraints-extras = haskell.lib.disableCabalFlag
-          super.constraints-extras
-          "build-readme";
-      })
-      (applyToPackages haskell.lib.doJailbreak [
-        "mono-traversable"
-      ])
-    ]);
-    inherit (haskell.packages) ghc884;
-    inherit (haskell.packages) ghc8107;
-    ghc901 = haskell.packages.ghc901.extend (composeExtensionList [
-      (applyToPackages haskell.lib.doJailbreak [
-        "pqueue"
-      ])
-    ]);
-    ghc921 = haskell.packages.ghc921.extend (composeExtensionList [
-      (applyToPackages haskell.lib.doJailbreak [
-        "postgresql-libpq"
-        "postgresql-simple"
-        "pqueue"
-      ])
-      (pinHackageVersions {
-        "some" = "1.0.3";
-        # This is not needed, but it tests the version bounds:
-        "vector-sized" = "1.5.0";
-      })
-      (pinHackageDirectVersions {
-        constraints-extras = {
-          pkg = "constraints-extras";
-          ver = "0.3.2.1";
-          sha256 = "03hsja50vzflqqmvvxgc9w32dqg51dlw8i0blpqb2ipv7njx4q2q";
-        };
-        hint = {
-          pkg = "hint";
-          ver = "0.9.0.5";
-          sha256 = "0x3yyq4vdpz4rqymbrq70swjpi0k6bnja0vhwlpgbgpzdb3ij7vc";
-        };
-      })
-      (self: _: {
-        # This is not needed, but it tests the version bounds:
-        aeson = self.aeson_2_0_1_0;
-      })
-    ]);
+    inherit (haskell.packages) ghc88;
+    inherit (haskell.packages) ghc810;
+    inherit (haskell.packages) ghc90;
+    inherit (haskell.packages) ghc92;
   };
 
+  # Currently unused as we don't need any overrides with current nixpkgs
+  # and GHC versions.
   composeExtensionList = lib.foldr lib.composeExtensions (_: _: {});
   applyToPackages = f: packages: _: super: lib.genAttrs packages
     (name: f super."${name}");

--- a/nix/nixpkgs.nix
+++ b/nix/nixpkgs.nix
@@ -1,4 +1,4 @@
 import (builtins.fetchTarball {
-    url = "https://github.com/NixOS/nixpkgs/tarball/86453059bf8312f0f5bf1fe8a2f52da2be664489";
-    sha256 = "0inzy97dp5988cwjwpn41219rir4c7qp7wwg7v4abcs9lypg8is4";
+    url = "https://github.com/NixOS/nixpkgs/tarball/85bcb95aa83be667e562e781e9d186c57a07d757";
+    sha256 = "0r8qmv8xlv8l18fd9zc8vw62d5w7pq5nnx51d9wsw6qdcl6m2jc4";
 })


### PR DESCRIPTION
Planning to follow up with GHC 9.4/9.6, but those will require more changes.