### PR TITLE
Fix building queries with WHERE in the absence of FROM.

### DIFF
--- a/beam-core/Database/Beam/Query/SQL92.hs
+++ b/beam-core/Database/Beam/Query/SQL92.hs
@@ -224,7 +224,7 @@ buildSql92Query' arbitrarilyNestedCombinations baseTblPfx (Q q) =
                -> Free (QF be db s) x
                -> SelectBuilder be db x
     buildQuery _ (Pure x) = SelectBuilderQ x emptyQb
-    buildQuery tblPfx (Free (QGuard _ next)) = buildQuery tblPfx next
+    buildQuery tblPfx f@(Free (QGuard _ _)) = buildJoinedQuery tblPfx f emptyQb
     buildQuery tblPfx f@(Free QAll {}) = buildJoinedQuery tblPfx f emptyQb
     buildQuery tblPfx f@(Free QArbitraryJoin {}) = buildJoinedQuery tblPfx f emptyQb
     buildQuery tblPfx f@(Free QTwoWayJoin {}) = buildJoinedQuery tblPfx f emptyQb


### PR DESCRIPTION
A WHERE clause in a query is meaningful even if there are no input tables. It makes the difference between there being 0 or 1 results. We therefore should not drop guards when building queries.

See #667.