### PR TITLE
Improved error for ColumnTypeMismatch

### DIFF
--- a/beam-postgres/Database/Beam/Postgres/Connection.hs
+++ b/beam-postgres/Database/Beam/Postgres/Connection.hs
@@ -154,12 +154,14 @@ runPgRowReader conn rowIdx res fields (FromBackendRowM readRow) =
                           case pgErr of
                             Pg.ConversionFailed { Pg.errSQLType = sql
                                                 , Pg.errHaskellType = hs
-                                                , Pg.errMessage = msg } ->
-                              pure (ColumnTypeMismatch hs sql msg)
+                                                , Pg.errMessage = msg
+                                                , Pg.errSQLField = field } ->
+                              pure (ColumnTypeMismatch hs sql ("Conversion failed for field'" <> field <> "': " <> msg))
                             Pg.Incompatible { Pg.errSQLType = sql
                                             , Pg.errHaskellType = hs
-                                            , Pg.errMessage = msg } ->
-                              pure (ColumnTypeMismatch hs sql msg)
+                                            , Pg.errMessage = msg
+                                            , Pg.errSQLField = field } ->
+                              pure (ColumnTypeMismatch hs sql ("Incompatible field: '" <> field <> "': " <> msg))
                             Pg.UnexpectedNull {} ->
                               pure ColumnUnexpectedNull
              in pure (Left (BeamRowReadError (Just (fromIntegral curCol)) err))


### PR DESCRIPTION
I was getting `ColumnTypeMismatch` errors and finding them to be pretty opaque if you don't know what column is causing the problem.

It turns out the [Postgres error types](https://hackage.haskell.org/package/postgresql-simple-0.7.0.0/docs/Database-PostgreSQL-Simple.html#t:ResultError) have an `errSQLField` which is useful to expose in the error message.