### PR TITLE
Changed documentation example of withDbModification function.

### DIFF
--- a/beam-core/Database/Beam/Schema/Tables.hs
+++ b/beam-core/Database/Beam/Schema/Tables.hs
@@ -187,7 +187,9 @@ tableModification = runIdentity $
 -- > db = defaultDbSettings `withDbModification`
 -- >      dbModification {
 -- >        -- Change default name "table1" to "Table_1". Change the name of "table1Field1" to "first_name"
--- >        table1 = modifyTable (\_ -> "Table_1") (tableModification { table1Field1 = "first_name" }
+-- >        table1 = setEntityName "Table_1" <> modifyTableFields tableModification { 
+-- >            table1Field1 = "first_name" 
+-- >         }
 -- >      }
 withDbModification :: forall db be entity
                     . Database be db


### PR DESCRIPTION
## Issue
In the documentation example of the `withDbModification` function, the `modifyTable` function was used, but it has been deprecated. Additionally, the closing parenthesis was missing.

## Solution

I modified the example to use `setEntityName` and `modifyTableFields` as recommended.

Do let me know, if any changes are required. Thanks!

@kmicklas 