### PR TITLE
document `beam-migrate` as a dependency rather than an executable

### DIFF
--- a/docs/schema-guide/migrations.md
+++ b/docs/schema-guide/migrations.md
@@ -6,13 +6,8 @@ The migrations framework is meant to be a robust and modular way of
 managing schema changes. It is an optional part of beam provided in
 the `beam-migrate` package.
 
-Install the migrations framework by running.
-
-```
-$ cabal install beam-migrate
-# or
-$ stack install beam-migrate
-```
+Add the `beam-migrate` dependency to get started:
+https://hackage.haskell.org/package/beam-migrate
 
 ## Basic concepts
 


### PR DESCRIPTION
`beam-migrate` CLI tool has been deleted: https://github.com/haskell-beam/beam/pull/684