### PR TITLE
provide `Generic` instances for `...SQL.Types`

### DIFF
--- a/beam-core/Database/Beam/Backend/SQL/Types.hs
+++ b/beam-core/Database/Beam/Backend/SQL/Types.hs
@@ -3,14 +3,15 @@ module Database.Beam.Backend.SQL.Types where
 
 import qualified Data.Aeson as Json
 import           Data.Bits
+import           GHC.Generics (Generic)
 
 data SqlNull = SqlNull
-  deriving (Show, Eq, Ord, Bounded, Enum)
+  deriving (Show, Eq, Ord, Bounded, Enum, Generic)
 newtype SqlBitString = SqlBitString Integer
-  deriving (Show, Eq, Ord, Enum, Bits)
+  deriving (Show, Eq, Ord, Enum, Bits, Generic)
 
 newtype SqlSerial a = SqlSerial { unSerial :: a }
-  deriving (Show, Read, Eq, Ord, Num, Integral, Real, Enum)
+  deriving (Show, Read, Eq, Ord, Num, Integral, Real, Enum, Generic)
 
 instance Json.FromJSON a => Json.FromJSON (SqlSerial a) where
   parseJSON a = SqlSerial <$> Json.parseJSON a


### PR DESCRIPTION
Helps with QuickCheck on datatypes built on top of these built-in types