### PR TITLE
Remove direct dependence of `beam-sqlite` on platform-specific packages

### DIFF
--- a/beam-sqlite/ChangeLog.md
+++ b/beam-sqlite/ChangeLog.md
@@ -1,23 +1,30 @@
+# 0.5.4.0
+
+## Added features
+
+ * Removed the reliance on either the `unix` or `windows` package, which should enable (#738)
+   `beam-sqlite` to be buildable on a wider variety of platforms.
+
 # 0.5.3.1
 
-# Added features
+## Added features
 
  * Replaced use of deprecated functions.
 
 # 0.5.3.0
 
-# Added features
+## Added features
 
  * Loosen some version bounds
  * `HasSqlEqualityCheck` instance for `Day`
 
 # 0.5.2.0
 
-# Bug fixes
+## Bug fixes
 
  * Fix encoding for `UTCTime`
 
-# Addded features
+## Addded features
 
  * `IN (SELECT ...)` syntax via `inQuery_`
 

--- a/beam-sqlite/beam-sqlite.cabal
+++ b/beam-sqlite/beam-sqlite.cabal
@@ -1,5 +1,5 @@
 name:                beam-sqlite
-version:             0.5.3.1
+version:             0.5.4.0
 synopsis:            Beam driver for SQLite
 description:         Beam driver for the <https://sqlite.org/ SQLite> embedded database.
                      See <https://haskell-beam.github.io/beam/user-guide/backends/beam-sqlite/ here>
@@ -49,13 +49,6 @@ library
   ghc-options:        -Wall
   if flag(werror)
     ghc-options:       -Werror
-
-  if os(windows)
-    cpp-options:      -DWINDOWS
-    build-depends:    Win32         >=2.4 && <2.8
-  if os(freebsd) || os(netbsd) || os(openbsd) || os(darwin) || os(linux) || os(solaris) || os(android)
-    cpp-options:      -DUNIX
-    build-depends:    unix          >=2.0 && <2.9
 
 test-suite beam-sqlite-tests
   type: exitcode-stdio-1.0


### PR DESCRIPTION
This PR removes `beam-sqlite`'s direct dependence on either the `unix` or `windows` package, which should allow to build `beam-core` and `beam-sqlite` on a wider variety of platforms.

Fixes #738  

Before merging, I want to at least manually check that `beam-sqlite` can be compiled using the WASM backend