### PR TITLE
Fix a marshalling error for columns of type `Maybe (Vector a)`

### DIFF
--- a/beam-postgres/ChangeLog.md
+++ b/beam-postgres/ChangeLog.md
@@ -1,3 +1,9 @@
+# Unreleased
+
+## Bug fixes
+
+ * Fixed an issue where columns of type `Maybe (Vector a)` did not marshall correctly from the database. In particular, querying a `Nothing` would return `Just (Vector.fromList [])` instead (#692).
+
 # 0.5.4.1
 
 ## Bug fixes

--- a/beam-postgres/Database/Beam/Postgres/Types.hs
+++ b/beam-postgres/Database/Beam/Postgres/Types.hs
@@ -155,12 +155,7 @@ instance FromBackendRow Postgres [Char]
 instance FromBackendRow Postgres (Ratio Integer)
 instance FromBackendRow Postgres (CI Text)
 instance FromBackendRow Postgres (CI TL.Text)
-instance (Pg.FromField a, Typeable a) => FromBackendRow Postgres (Vector a) where
-  fromBackendRow = do
-      isNull <- peekField
-      case isNull of
-        Just SqlNull -> pure mempty
-        Nothing -> parseOneField @Postgres @(Vector a)
+instance (Pg.FromField a, Typeable a) => FromBackendRow Postgres (Vector a)
 instance (Pg.FromField a, Typeable a) => FromBackendRow Postgres (Pg.PGArray a)
 instance FromBackendRow Postgres (Pg.Binary ByteString)
 instance FromBackendRow Postgres (Pg.Binary BL.ByteString)


### PR DESCRIPTION
This pull request fixes a small conversion error where querying `Nothing` from a column of type `Maybe (Vector a)` would return `Just []` instead of `Nothing`.

Fixes #692 