### PR TITLE
Support Postgres array migrations

### DIFF
--- a/beam-postgres/ChangeLog.md
+++ b/beam-postgres/ChangeLog.md
@@ -1,3 +1,9 @@
+# Unreleased
+
+## Bug fixes
+
+ * Added the ability to migrate Postgres' array types (#354).
+
 # 0.5.4.2
 
 ## Bug fixes


### PR DESCRIPTION
This pull request adds the ability to migrate Postgres' Array types.

Note that the mechanism by which this is done is still unsafe; if trying to migrate to an array type whose elements are unsupported (i.e. array OIDs that [don't exist here](https://hackage.haskell.org/package/postgresql-simple-0.7.0.0/docs/Database-PostgreSQL-Simple-TypeInfo-Static.html)), then the migration will result in a runtime error rather than a compile time error.

Breaking changes would have to be made to get compile-time safety of array migrations. 

Fixes #354 