### PR TITLE
Make the input of `values_` a non-empty list

### DIFF
--- a/beam-postgres/test/Database/Beam/Postgres/Test/Select.hs
+++ b/beam-postgres/test/Database/Beam/Postgres/Test/Select.hs
@@ -4,6 +4,7 @@ module Database.Beam.Postgres.Test.Select (tests) where
 
 import           Data.Aeson
 import           Data.ByteString (ByteString)
+import qualified Data.List.NonEmpty as NonEmpty
 import           Data.Int
 import qualified Data.Vector as V
 import           Test.Tasty
@@ -82,7 +83,7 @@ testUuuidInValues getConn = testCase "UUID in values_ works" $
         pgCreateExtension @UuidOssp
       let ext = getPgExtension $ _uuidOssp $ unCheckDatabase db
       runSelectReturningList $ select $ do
-        v <- values_ [val_ nil]
+        v <- values_ (NonEmpty.singleton (val_ nil))
         return $ pgUuidGenerateV5 ext v ""
     assertEqual "result" [V5.generateNamed nil []] result
 

--- a/beam-sqlite/test/Database/Beam/Sqlite/Test/Select.hs
+++ b/beam-sqlite/test/Database/Beam/Sqlite/Test/Select.hs
@@ -6,6 +6,8 @@ import Data.Int (Int32)
 
 import Database.Beam
 import Database.Beam.Sqlite
+import Data.List.NonEmpty (NonEmpty(..))
+import qualified Data.List.NonEmpty as NonEmpty
 import Test.Tasty
 import Test.Tasty.ExpectedFailure
 import Test.Tasty.HUnit
@@ -51,5 +53,5 @@ testExceptValues :: TestTree
 testExceptValues = testCase "EXCEPT with VALUES works" $
   withTestDb $ \conn -> do
     result <- runBeamSqlite conn $ runSelectReturningList $ select $
-      values_ [as_ @Bool $ val_ True, val_ False] `except_` values_ [val_ False]
+      values_ ((as_ @Bool $ val_ True) :| [ val_ False]) `except_` values_ (NonEmpty.singleton (val_ False))
     assertEqual "result" [True] result

--- a/docs/beam-templates/chinook.hs
+++ b/docs/beam-templates/chinook.hs
@@ -13,6 +13,7 @@ import Control.Monad
 import Control.Exception
 
 import Data.IORef
+import Data.List.NonEmpty (NonEmpty(..))
 import Data.Monoid ((<>))
 import Data.Int
 import Data.Text

--- a/docs/user-guide/queries/select.md
+++ b/docs/user-guide/queries/select.md
@@ -222,7 +222,7 @@ For example, to get all customers we know to be in New York, California, and Tex
 ```haskell
 !example chinook !on:Sqlite !on:MySQL
 do c <- all_ (customer chinookDb)
-   st <- values_ [ "NY", "CA", "TX" ]
+   st <- values_ ("NY" :| [ "CA", "TX" ]) -- (:|) is the constructor of NonEmpty
    guard_' (just_ st ==?. addressState (customerAddress c))
    pure c
 ```


### PR DESCRIPTION
This pull request ensures that `values_` can no longer fail on an empty list, by requiring `NonEmpty` as input.

Fixes #559 

This pull request will be merged whenever there is a critical mass of breaking changes such that `beam-core-0.11` makes sense.