### PR TITLE
Updates to migration backends

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+\#*
 .beam-migrate
 cabal.sandbox.config
 .cabal-sandbox
@@ -8,7 +9,7 @@ dist-newstyle
 *.db
 *.db-journal
 .#*
-#*
+\#*
 graveyard
 *.o
 *.hi

--- a/beam-migrate/Database/Beam/Migrate/Backend.hs
+++ b/beam-migrate/Database/Beam/Migrate/Backend.hs
@@ -26,7 +26,7 @@
 --
 -- For an example migrate backend, see "Database.Beam.Sqlite.Migrate"
 module Database.Beam.Migrate.Backend
-  ( BeamMigrationBackend(..)
+  ( BeamMigrationBackend(..), BeamMigrateConnection(..)
   , DdlError
 
   -- * Haskell predicate conversion
@@ -88,8 +88,15 @@ data BeamMigrationBackend be m where
     , backendFileExtension :: String
     , backendConvertToHaskell :: HaskellPredicateConverter
     , backendActionProvider :: ActionProvider be
-    , backendTransact :: forall a. String -> m a -> IO (Either DdlError a)
+    , backendRunSqlScript :: Text -> m ()
+    , backendWithTransaction :: forall a. m a -> m a
+    , backendConnect :: String -> IO (BeamMigrateConnection be m)
     } -> BeamMigrationBackend be m
+
+data BeamMigrateConnection be m where
+    BeamMigrateConnection
+        :: { backendRun :: forall a. m a -> IO (Either DdlError a)
+           , backendClose :: IO () } -> BeamMigrateConnection be m
 
 -- | Monomorphic wrapper for use with plugin loaders that cannot handle
 -- polymorphism

--- a/beam-migrate/Database/Beam/Migrate/Serialization.hs
+++ b/beam-migrate/Database/Beam/Migrate/Serialization.hs
@@ -25,7 +25,8 @@ module Database.Beam.Migrate.Serialization
        , BeamDeserializers(..)
 
        , beamDeserialize, beamDeserializeMaybe
-       , beamDeserializer, sql92Deserializers
+       , beamDeserializer, beamDeserializeJSON
+       , sql92Deserializers
        , sql99DataTypeDeserializers
        , sql2003BinaryAndVarBinaryDataTypeDeserializers
        , sql2008BigIntDataTypeDeserializers
@@ -215,6 +216,15 @@ beamSerializeJSON :: Text -> Value -> Value
 beamSerializeJSON backend v =
   object [ "be-specific" .= backend
          , "be-data" .= v ]
+
+-- | Corresponding deserializer for 'beamSerializeJSON'
+beamDeserializeJSON :: Text -> (Value -> Parser a) -> Value -> Parser a
+beamDeserializeJSON backend go =
+  withObject "backend-specific item" $ \v -> do
+    be <- v .: "be-specific"
+    guard (be == backend)
+    d <- v .: "be-data"
+    go d
 
 -- | Helper for serializing the precision and decimal count parameters to
 -- 'decimalType', etc.


### PR DESCRIPTION
After several years, I've finally started working on a tool for beam migrations. I'll start a new repository for my tool, but there are some pieces missing from upstream beam that would be necessary for any migrations tool.

The key change here is adding a function to each backend to execute arbitrary SQL. This is necessary for any tool that allows running arbitrary migration scripts stored as backend-specific SQL.

The other major change is proper support for backend-agnostic transactions and proper connection handling.

All these changes are necessary for any migrations frontend, not just my tool.