### PR TITLE
Proper support for multi-line migration scripts in sqlite

### DIFF
--- a/beam-sqlite/Database/Beam/Sqlite/Migrate.hs
+++ b/beam-sqlite/Database/Beam/Sqlite/Migrate.hs
@@ -30,7 +30,8 @@ import           Control.Exception
 import           Control.Monad
 import           Control.Monad.Reader
 
-import           Database.SQLite.Simple (open, close, query_, execute_, Query(..))
+import           Database.SQLite.Simple (open, close, query_, execute_, connectionHandle)
+import           Database.SQLite3 (exec)
 
 import           Data.Aeson
 import           Data.Attoparsec.Text (asciiCI, skipSpace)
@@ -251,7 +252,8 @@ parseSqliteDataType txt =
 runSqlScript :: T.Text -> SqliteM ()
 runSqlScript t =
     SqliteM . ReaderT $ \(_, conn) ->
-      execute_ conn (Query t)
+        let hdl = connectionHandle conn
+        in exec hdl t
 
 -- TODO constraints and foreign keys
 

--- a/beam-sqlite/beam-sqlite.cabal
+++ b/beam-sqlite/beam-sqlite.cabal
@@ -42,13 +42,6 @@ library
                       aeson         >=0.11 && <2.3,
                       attoparsec    >=0.13 && <0.15,
                       transformers-base    >=0.4  && <0.5,
-                      -- Dependency on direct-sqlite is not direct,
-                      -- but functionality in beam-sqlite depends on
-                      -- a minimum version of sqlite. At this time,
-                      -- we require at least sqlite-3.24.
-                      -- Note that because of this, we cannot use the 
-                      -- `Wunused-packages` warning.
-                      -- See #589
                       direct-sqlite >=2.3.24
   default-language:   Haskell2010
   default-extensions: ScopedTypeVariables, OverloadedStrings, MultiParamTypeClasses, RankNTypes, FlexibleInstances,


### PR DESCRIPTION
Looks like my old changes were wrong. `sqlite-simple` doesn't offer any way to run multi-line SQL scripts. This is from the C `sqlite` library's `exec` function, which is only exposed in `direct-sqlite`. 