### PR TITLE
Convenience functions for custom data types in SQLite

### DIFF
--- a/beam-sqlite/Database/Beam/Sqlite.hs
+++ b/beam-sqlite/Database/Beam/Sqlite.hs
@@ -8,6 +8,8 @@ module Database.Beam.Sqlite
   , SqliteSelectSyntax, SqliteInsertSyntax
   , SqliteUpdateSyntax, SqliteDeleteSyntax
 
+  , SqliteDataTypeSyntax(..), mkSqliteDataType
+
   , fromSqliteCommand, sqliteRenderSyntaxScript
 
   ,  module Database.Beam.Sqlite.SqliteSpecific

--- a/beam-sqlite/Database/Beam/Sqlite/Migrate.hs
+++ b/beam-sqlite/Database/Beam/Sqlite/Migrate.hs
@@ -145,7 +145,7 @@ sqliteTypeToHs = Just . sqliteDataTypeToHs
 
 customSqliteDataType :: T.Text -> SqliteDataTypeSyntax
 customSqliteDataType txt =
-    SqliteDataTypeSyntax (emit (TE.encodeUtf8 txt) <> emit "{- custom -}")
+    SqliteDataTypeSyntax (emit (TE.encodeUtf8 txt) <> emit "/* unknown sqlite type */")
                          (hsErrorType ("Unknown SQLite datatype '" ++ T.unpack txt ++ "'"))
                          (Db.BeamSerializedDataType $
                             Db.beamSerializeJSON "sqlite"

--- a/beam-sqlite/Database/Beam/Sqlite/Syntax.hs
+++ b/beam-sqlite/Database/Beam/Sqlite/Syntax.hs
@@ -33,6 +33,7 @@ module Database.Beam.Sqlite.Syntax
   , SqliteDataTypeSyntax(..)
   , sqliteTextType, sqliteBlobType
   , sqliteBigIntType, sqliteSerialType
+  , mkSqliteDataType
 
     -- * Building and consuming 'SqliteSyntax'
   , fromSqliteCommand, formatSqliteInsert, formatSqliteInsertOnConflict
@@ -51,8 +52,10 @@ import           Database.Beam.Migrate.Checks (HasDataTypeCreatedCheck(..))
 import           Database.Beam.Migrate.SQL.Builder hiding (fromSqlConstraintAttributes)
 import           Database.Beam.Migrate.SQL.SQL92
 import           Database.Beam.Migrate.Serialization
+import qualified Database.Beam.Migrate.Serialization as Db
 import           Database.Beam.Query hiding (ExtractField(..))
 
+import           Data.Aeson (object, (.=))
 import           Data.ByteString (ByteString)
 import qualified Data.ByteString as B
 import           Data.ByteString.Builder
@@ -557,6 +560,12 @@ instance IsSql99DataTypeSyntax SqliteDataTypeSyntax where
 
 instance IsSql2008BigIntDataTypeSyntax SqliteDataTypeSyntax where
   bigIntType = sqliteBigIntType
+
+mkSqliteDataType :: String -> SqliteDataTypeSyntax
+mkSqliteDataType s = SqliteDataTypeSyntax (emit (fromString s)) (hsErrorType s)
+                       (Db.BeamSerializedDataType $
+                          Db.beamSerializeJSON "sqlite" (object [ "custom" .= s ]))
+                       False
 
 sqliteTextType, sqliteBlobType, sqliteBigIntType :: SqliteDataTypeSyntax
 sqliteTextType = SqliteDataTypeSyntax (emit "TEXT")


### PR DESCRIPTION
These functions make it easier to write custom data types for SQLite. SQLite is lax with how types are specified, so this is useful if you want to use custom type names for custom haskell data types. Will add documentation. 