### PR TITLE
Update lens generation documentation

### DIFF
--- a/docs/tutorials/tutorial2.md
+++ b/docs/tutorials/tutorial2.md
@@ -223,15 +223,18 @@ We can bring these lenses into scope globally via a global pattern match against
 -- Add the following to the top of the file, for GHC >8.2
 {-#  LANGUAGE ImpredicativeTypes #-}
 
-Address (LensFor addressId)    (LensFor addressLine1)
-        (LensFor addressLine2) (LensFor addressCity)
-        (LensFor addressState) (LensFor addressZip)
-        (UserId (LensFor addressForUserId)) =
-        tableLenses
+Address (LensFor addressId) _ _ _ _ _ _ = tableLenses
+Address _ (LensFor addressLine1) _ _ _ _ _ = tableLenses
+Address _ _ (LensFor addressLine2) _ _ _ _ = tableLenses
+Address _ _ _ (LensFor addressCity) _ _ _ = tableLenses
+Address _ _ _ _ (LensFor addressState) _ _ = tableLenses
+Address _ _ _ _ _ (LensFor addressZip) _ = tableLenses
+Address _ _ _ _ _ _ (UserId (LensFor addressForUserId)) = tableLenses
 
-User (LensFor userEmail)    (LensFor userFirstName)
-     (LensFor userLastName) (LensFor userPassword) =
-     tableLenses
+User (LensFor userEmail) _ _ _ = tableLenses
+User _ (LensFor userFirstName) _ _ = tableLenses
+User _ _ (LensFor userLastName) _ = tableLenses
+User _ _ _ (LensFor userPassword) = tableLenses
 ```
 
 !!! note "Note"

--- a/docs/tutorials/tutorial2.md
+++ b/docs/tutorials/tutorial2.md
@@ -216,8 +216,8 @@ We can use beam's `Columnar` mechanism to automatically derive lenses. The
 polymorphic Van Laarhoven lens.
 
 We can bring these lenses into scope globally via a global pattern match against
-`tableLenses`. For example, to get lenses for each column of the `AddressT` and
-`UserT` table.
+`tableLenses`. For example, we get lenses for each column of the `AddressT` and
+`UserT` table below.
 
 ```haskell
 -- Add the following to the top of the file, for GHC >8.2

--- a/docs/tutorials/tutorial2.md
+++ b/docs/tutorials/tutorial2.md
@@ -240,7 +240,9 @@ User _ _ _ (LensFor userPassword) = tableLenses
 !!! note "Note"
     The `ImpredicativeTypes` language extension is necessary for newer
     GHC to allow the polymorphically typed lenses to be introduced at
-    the top-level. Older GHCs were more lenient.
+    the top-level. Older GHCs were more lenient. As for why we must
+    create a separate pattern match for each lens we would like to
+    generate, please refer to GitHub issues [#659](https://github.com/haskell-beam/beam/issues/659) and [#664](https://github.com/haskell-beam/beam/issues/664).
 
 As in tables, we can generate lenses for databases via the `dbLenses` function.
 

--- a/docs/tutorials/tutorial3.md
+++ b/docs/tutorials/tutorial3.md
@@ -120,7 +120,10 @@ Now we'll add all these tables to our database.
 -- Some convenience lenses
 
 LineItem _ _ (LensFor lineItemQuantity) = tableLenses
-Product (LensFor productId) (LensFor productTitle) (LensFor productDescription) (LensFor productPrice) = tableLenses
+Product (LensFor productId) _ _ _ = tableLenses
+Product _ (LensFor productTitle) _ _ = tableLenses
+Product _ _ (LensFor productDescription) _ = tableLenses
+Product _ _ _ (LensFor productPrice) = tableLenses
 
 data ShoppingCartDb f = ShoppingCartDb
                       { _shoppingCartUsers         :: f (TableEntity UserT)
@@ -131,9 +134,12 @@ data ShoppingCartDb f = ShoppingCartDb
                       , _shoppingCartLineItems     :: f (TableEntity LineItemT) }
                         deriving (Generic, Database be)
 
-ShoppingCartDb (TableLens shoppingCartUsers) (TableLens shoppingCartUserAddresses)
-               (TableLens shoppingCartProducts) (TableLens shoppingCartOrders)
-               (TableLens shoppingCartShippingInfos) (TableLens shoppingCartLineItems) = dbLenses
+ShoppingCartDb (TableLens shoppingCartUsers) _ _ _ _ _ = dbLenses
+ShoppingCartDb _ (TableLens shoppingCartUserAddresses) _ _ _ _ = dbLenses
+ShoppingCartDb _ _ (TableLens shoppingCartProducts) _ _ _  = dbLenses
+ShoppingCartDb _ _ _ (TableLens shoppingCartOrders) _ _ = dbLenses
+ShoppingCartDb _ _ _ _ (TableLens shoppingCartShippingInfos) _  = dbLenses
+ShoppingCartDb _ _ _ _ _ (TableLens shoppingCartLineItems) = dbLenses
 
 shoppingCartDb :: DatabaseSettings be ShoppingCartDb
 shoppingCartDb = defaultDbSettings `withDbModification`


### PR DESCRIPTION
This PR updates the documentation regarding lens generation to reflect the extra pattern matches that appear to be necessary with newer versions of GHC (as described in [#659](https://github.com/haskell-beam/beam/issues/659) and [#664](https://github.com/haskell-beam/beam/issues/664)).