### PR TITLE
beam-sqlite.cabal: skip incompatible beam-migrate

### DIFF
--- a/beam-sqlite/beam-sqlite.cabal
+++ b/beam-sqlite/beam-sqlite.cabal
@@ -26,7 +26,7 @@ library
   build-depends:      base          >=4.11 && <5,
 
                       beam-core     >=0.10 && <0.11,
-                      beam-migrate  >=0.5  && <0.6,
+                      beam-migrate  >=0.5  && <0.5.3.2,
 
                       sqlite-simple >=0.4  && <0.5,
                       text          >=1.0  && <2.2,


### PR DESCRIPTION
Hello!

Looking at beam for the first time, I struggled a bit to get going due to a dependency conflict.

The latest beam-sqlite v=0.5.4.0 is not compatible with the latest beam-migrate v=0.5.3.2

v0.5.3.2 introduced a requirement on Text vs String so a compilation error ensues.

I suppose leaving the PR open to document the minimal working setup until this is fixed is a good option too.

```
-- myProject.cabal

-- The latest beam-sqlite v=0.5.4.0 is not compatible with the latest beam-migrate v=0.5.3.2 (which it depends on)
build-depends:    base ^>=4.18.3.0
                , beam-core
                , beam-sqlite == 0.5.4.0
                , beam-migrate == 0.5.3.1
               ...
```

I didn't find it very intuitive that beam-sqlite depends on beam-migrate (I'm more interested in beam for it's query ability, not so much the migration part)

Maybe you should introduce semantic versioning?