### PR TITLE
Build, check, and store release artifacts

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -40,7 +40,7 @@ jobs:
       with:
         ghc-version: ${{ matrix.ghc-version }}
         cabal-version: '3.12.1.0'
-    
+
     - name: Generate freeze file
       run: |
         cabal update
@@ -51,7 +51,7 @@ jobs:
         # avoid invalidating cache too often.
         # This idea comes from github.com/jaspervdj/hakyll
         sed '/^index-state: /d' cabal.project.freeze > dependencies-versions
-    
+
     - name: Cache cabal work
       uses: actions/cache@v4
       with:
@@ -59,15 +59,45 @@ jobs:
           dist-newstyle
           ${{ steps.setup-haskell.outputs.cabal-store }}
         key: ${{ runner.os }}-${{ hashFiles('dependencies-versions', 'cabal.project.local') }}-cabal-install
-    
+
     - name: Build dependencies
       run: |
         cabal build all --only-dependencies ${{matrix.cabal-flags}}
-    
+
     - name: Build beam packages
       run: |
         cabal build all ${{matrix.cabal-flags}}
-        
+
     - name: Run tests
       run: |
         cabal test all ${{matrix.cabal-flags}}
+
+  release-artifacts:
+    # Only build release artifacts if `continuous-integration` is successful
+    needs: [continuous-integration]
+    runs-on: ubuntu-24.04
+
+    steps:
+    - name: Check packages for common mistakes
+      run: |
+        current_dir=$PWD
+        for pkg in ./beam-*; do
+          cd $pkg
+          echo "Checking $pkg"
+          cabal check
+          cd $current_dir
+        done
+    
+    # Note that the ubuntu-24.04 image includes cabal
+    # https://github.com/actions/runner-images/blob/main/images/ubuntu/Ubuntu2404-Readme.md#haskell-tools
+    - name: Build release artifacts
+      run : |
+        cabal sdist
+
+    - name: Upload build artifacts
+      uses: actions/upload-artifact@v4
+      if: github.ref == 'refs/heads/master'
+      with:
+        name: ${{ runner.os }}-release-artifact
+        path: dist-newstyle/sdist/*
+        retention-days: 7

--- a/RELEASE-CHECKLIST.md
+++ b/RELEASE-CHECKLIST.md
@@ -1,0 +1,10 @@
+# Release checklist
+
+For any given package that you want to release:
+
+[ ] Update the version in the appropriate cabal file;
+[ ] Update the relevant CHANGELOG.md if necessary;
+[ ] Commit and push;
+[ ] Wait for the Github Actions pipeline to complete;
+[ ] Download the release artifacts from the build on Github Actions;
+[ ] Release to Hackage: `cabal upload --publish <release-artifact>`.

--- a/script.sh
+++ b/script.sh
@@ -1,0 +1,7 @@
+current_dir=$PWD
+for pkg in ./beam-*; do
+    cd $pkg
+    echo "Checking $pkg"
+    cabal check
+    cd $current_dir
+done


### PR DESCRIPTION
This PR adds a new Github Actions job to build, check, and store release artifacts to Github.

Fixes #765 